### PR TITLE
Pablo.issue25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ All notable changes to this project will be documented in this file. `Jayme` a
 
 ## 2.0.0
 
-- `path` variable has been renamed to `name` in `Repository` protocol declaration.
-- `ServerBackend` protocol has been renamed to `NSURLSessionBackend`.
-- `ServerBackendConfiguration` has been renamed to `NSURLSessionBackendConfiguration`.
-- `ServerBackendError` has been renamed to `JaymeError`.
-- `ServerRepository` has been renamed to `CRUDRepository`.
-- `StringDictionary` typealias has been removed.
-- `init?(dictionary)` has been replaced by `init(dictionary) throws` in `DictionaryInitializable` protocol.
+- `path` variable has been renamed to `name` in `Repository` protocol declaration. (Issue [#17](https://github.com/inaka/Jayme/issues/17))
+- `ServerBackend` protocol has been renamed to `NSURLSessionBackend`. (Issue [#18](https://github.com/inaka/Jayme/issues/18))
+- `ServerBackendConfiguration` has been renamed to `NSURLSessionBackendConfiguration`. (Issue [#18](https://github.com/inaka/Jayme/issues/18))
+- `ServerBackendError` has been renamed to `JaymeError`. (Issue [#21](https://github.com/inaka/Jayme/issues/21))
+- `ServerRepository` has been renamed to `CRUDRepository`. (Issue [#19](https://github.com/inaka/Jayme/issues/19))
+- `StringDictionary` typealias has been removed. (Issue [#28](https://github.com/inaka/Jayme/issues/28))
+- `init?(dictionary)` has been replaced by `init(dictionary) throws` in `DictionaryInitializable` protocol. (Issue [#25](https://github.com/inaka/Jayme/issues/25))
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file. `Jayme` a
 - `ServerBackendError` has been renamed to `JaymeError`.
 - `ServerRepository` has been renamed to `CRUDRepository`.
 - `StringDictionary` typealias has been removed.
+- `init?(dictionary)` has been replaced by `init(dictionary) throws` in `DictionaryInitializable` protocol.
 
 ---
 

--- a/Documentation/Jayme 2.0 Migration Guide.md
+++ b/Documentation/Jayme 2.0 Migration Guide.md
@@ -1,0 +1,39 @@
+# Jayme 2.0 Migration Guide
+
+**Jayme 2.0** is the latest major release of Jayme. As a major release, following Semantic Versioning conventions, 2.0 introduces several API-breaking changes that one should be aware of.
+
+This guide is provided in order to ease the transition of existing applications using Jayme 1.x to the latest APIs, as well as explain the design and structure of new and changed functionality.
+
+---
+
+### Automatically Suggested Changes
+
+There are some compiler migration mechanisms that have been implemented in Jayme 2.0 by leveraging the `@unavailable` attribute in a `Compatibility.swift` file.
+
+***For these changes you only have to follow the compiler suggestions and they should be applied automatically.***
+
+For instance:
+
+* `ServerRepository` has been renamed to `CRUDRepository`. 
+  * The compiler will automatically suggest the replacement of `ServerRepository` to `CRUDRepository`.
+
+---
+
+### Manual Changes
+
+However, there are some other changes that would have required overwhelming (if ever possible) mechanisms to be implemented in order to keep automatic suggestions from the compiler. In consequence, we decided not to implement them but to write them down here in a separated list.
+
+⚠️ ***Therefore, it's up to you to perform these changes manually.***
+
+They are listed below:
+
+- `path` variable has been renamed to `name` in `Repository` protocol declaration (related issue: [#17](https://github.com/inaka/Jayme/issues/17)).
+  - You have to change every `path` appearance in your Repositories by using `name` instead.
+- `init?(dictionary: StringDictionary)` has been replaced by `init(dictionary: [String: AnyObject]) throws` (related issues: [#25](https://github.com/inaka/Jayme/issues/25), [#28](https://github.com/inaka/Jayme/issues/28)).
+  - `StringDictionary` → `[String: AnyObject]` replacements should be suggested by the compiler.
+  - You have to manually replace your `init?` initializers for every class or struct that conforms to `DictionaryInitializable` by its throwable equivalent.
+  - You have to perform `{ throw JaymeError.ParsingError }` whenever you can't initialize a `DictionaryInitializable` object instead of performing `{ return nil }`.
+
+---
+
+For further documentation regarding changes, check out the **[Change Log](../Changelog.md)**.

--- a/Example/Post.swift
+++ b/Example/Post.swift
@@ -33,7 +33,7 @@ struct Post: Identifiable {
 
 extension Post: DictionaryInitializable, DictionaryRepresentable {
     
-    init?(dictionary: [String: AnyObject]) {
+    init(dictionary: [String: AnyObject]) throws {
         guard let
             id = dictionary["id"] as? String,
             authorID = dictionary["author_id"] as? String,
@@ -41,7 +41,7 @@ extension Post: DictionaryInitializable, DictionaryRepresentable {
             abstract = dictionary["abstract"] as? String,
             dateString = dictionary["date"] as? String,
             date = dateString.toDate()
-            else { return nil }
+            else { throw JaymeError.ParsingError }
         self.id = id
         self.authorID = authorID
         self.title = title

--- a/Example/User.swift
+++ b/Example/User.swift
@@ -31,12 +31,12 @@ struct User: Identifiable {
 
 extension User: DictionaryInitializable, DictionaryRepresentable {
     
-    init?(dictionary: [String: AnyObject]) {
+    init(dictionary: [String: AnyObject]) throws {
         guard let
             id = dictionary["id"] as? String,
             name = dictionary["name"] as? String,
             email = dictionary["email"] as? String
-            else { return nil }
+            else { throw JaymeError.ParsingError }
         self.id = id
         self.name = name
         self.email = email

--- a/Jayme/CRUDRepository.swift
+++ b/Jayme/CRUDRepository.swift
@@ -116,7 +116,7 @@ public extension CRUDRepository {
     /// Converts an array of dictionaries to an array of Entities, and returns a corresponding `Future`
     public func parseEntitiesFromArray(array: [[String: AnyObject]]) -> Future<[EntityType], JaymeError> {
         return Future() { completion in
-            let entities = array.flatMap({ EntityType(dictionary: $0) })
+            let entities = array.flatMap({ try? EntityType(dictionary: $0) })
             completion(.Success(entities))
         }
     }
@@ -124,7 +124,7 @@ public extension CRUDRepository {
     /// Converts a single dictionary to an Entity, and returns a corresponding `Future`
     public func parseEntityFromDictionary(dictionary: [String: AnyObject]) -> Future<EntityType, JaymeError> {
         return Future() { completion in
-            guard let entity = EntityType(dictionary: dictionary) else {
+            guard let entity = try? EntityType(dictionary: dictionary) else {
                 completion(.Failure(.ParsingError))
                 return
             }

--- a/Jayme/DictionaryInitializable.swift
+++ b/Jayme/DictionaryInitializable.swift
@@ -25,5 +25,5 @@ import Foundation
 
 /// Protocol for allowing entities to be initialized (parsed in) from a dictionary
 public protocol DictionaryInitializable {
-    init?(dictionary: [String: AnyObject])
+    init(dictionary: [String: AnyObject]) throws
 }

--- a/JaymeTests/TestDocument.swift
+++ b/JaymeTests/TestDocument.swift
@@ -31,13 +31,11 @@ struct TestDocument: Identifiable {
 
 extension TestDocument: DictionaryInitializable, DictionaryRepresentable {
     
-    init?(dictionary: [String: AnyObject]) {
+    init(dictionary: [String: AnyObject]) throws {
         guard let
             id = dictionary["id"] as? String,
             name = dictionary["name"] as? String
-            else {
-                return nil
-        }
+            else { throw JaymeError.ParsingError }
         self.id = id
         self.name = name
     }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ It provides a neat API for dealing with REST communication, leaving your `ViewCo
 
 ![Jayme's Architecture In A Nutshell](https://raw.githubusercontent.com/inaka/Jayme/master/Assets/architecture-diagram-1.png)
 
+## Migration Guides
 
+- [Jayme 2.0 Migration Guide](https://github.com/inaka/Jayme/blob/master/Documentation/Jayme%202.0%20Migration%20Guide.md)
 
 ##Features
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It provides a neat API for dealing with REST communication, leaving your `ViewCo
   - Unit-tests are easy to implement (and, of course, encouraged) in your own repositories, backends and entities. Check out how Jayme unit tests work to see examples. You're going to encounter several fakes that are easy to reuse and adapt to your tests.
 - **No Dependencies**
   - Jayme does not leverage any external dependency. We consider simplicity to be a very important concept to keep always in mind.
-  - Nonetheless, we highly suggest that you integrate [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON) hand in hand with Jayme, to make your life easier when it comes to fill out `init?(dictionary)` methods for your Entities. You can turn a `dictionary` into a `JSON` object very quickly and parse out the relevant data easily from that point.
+  - Nonetheless, we highly suggest that you integrate [SwiftyJSON](https://github.com/SwiftyJSON/SwiftyJSON) hand in hand with Jayme, to make your life easier when it comes to fill out `init(dictionary)` methods for your Entities. You can turn a `dictionary` into a `JSON` object very quickly and parse out the relevant data easily from that point.
 
 
 
@@ -134,13 +134,13 @@ struct User: Identifiable {
 
 extension User: DictionaryInitializable, DictionaryRepresentable {
     
-    init?(dictionary: [String: AnyObject]) {
+    init(dictionary: [String: AnyObject]) throws {
         let json = JSON(dictionary)
         guard let
             id = json["id"].string,
             name = json["name"].string,
             email = json["email"].string
-            else { return nil }
+            else { throw JaymeError.ParsingError }
         self.id = id
         self.name = name
         self.email = email
@@ -244,13 +244,13 @@ struct Post: Identifiable {
 
 extension Post: DictionaryInitializable, DictionaryRepresentable {
     
-    init?(dictionary: [String: AnyObject]) {
+    init(dictionary: [String: AnyObject]) throws {
         let json = JSON(dictionary)
         guard let
             id = json["id"].string,
             authorID = json["author_id"].string,
             content = json["content"].string
-            else { return nil }
+            else { throw JaymeError.ParsingError }
         self.id = id
         self.authorID = authorID
         self.content = content


### PR DESCRIPTION
- Solves issue #25.
- `init?(dictionary)` → `init(dictionary) throws` in `DictionaryInitializable`.
- Updated everything accordingly to renaming checklist.
- Added **Jayme 2.0 Migration Guide** with relevant information for both automatic and manual changes.
