### PR TITLE
Pablo.issue20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file. `Jayme` a
 - `ServerRepository` has been renamed to `CRUDRepository`. (Issue [#19](https://github.com/inaka/Jayme/issues/19))
 - `StringDictionary` typealias has been removed. (Issue [#28](https://github.com/inaka/Jayme/issues/28))
 - `init?(dictionary)` has been replaced by `init(dictionary) throws` in `DictionaryInitializable` protocol. (Issue [#25](https://github.com/inaka/Jayme/issues/25))
+- `PagedRepository` no longer conforms to `CRUDRepository` (ex `ServerRepository`); now it conforms directly to `Repository`. (Issue [#20](https://github.com/inaka/Jayme/issues/20))
+- Convenient parsing functions have been plucked out from `CRUDRepository` (ex `ServerRepository`) and put into new classes named `DataParser` and `EntityParser`.  (Issue [#20](https://github.com/inaka/Jayme/issues/20))
 
 ---
 

--- a/Documentation/Jayme 2.0 Migration Guide.md
+++ b/Documentation/Jayme 2.0 Migration Guide.md
@@ -27,12 +27,19 @@ However, there are some other changes that would have required overwhelming (if 
 
 They are listed below:
 
-- `path` variable has been renamed to `name` in `Repository` protocol declaration (related issue: [#17](https://github.com/inaka/Jayme/issues/17)).
+- `path` variable has been renamed to `name` in `Repository` protocol declaration. (related issue: [#17](https://github.com/inaka/Jayme/issues/17))
   - You have to change every `path` appearance in your Repositories by using `name` instead.
-- `init?(dictionary: StringDictionary)` has been replaced by `init(dictionary: [String: AnyObject]) throws` (related issues: [#25](https://github.com/inaka/Jayme/issues/25), [#28](https://github.com/inaka/Jayme/issues/28)).
+- `init?(dictionary: StringDictionary)` has been replaced by `init(dictionary: [String: AnyObject]) throws`. (related issues: [#25](https://github.com/inaka/Jayme/issues/25), [#28](https://github.com/inaka/Jayme/issues/28))
   - `StringDictionary` → `[String: AnyObject]` replacements should be suggested by the compiler.
   - You have to manually replace your `init?` initializers for every class or struct that conforms to `DictionaryInitializable` by its throwable equivalent.
   - You have to perform `{ throw JaymeError.ParsingError }` whenever you can't initialize a `DictionaryInitializable` object instead of performing `{ return nil }`.
+
+- Convenient parsing functions under one of the extensions in `ServerRepository` (now `CRUDRepository`) have been moved into separated new classes called `DataParser` and `EntityParser`. If you were calling those functions somewhere in your code, you have to change their calls to use those parsers classes instead of your repository itself. (related issue: [#20](https://github.com/inaka/Jayme/issues/20))
+  - Possible replacements are:
+    - `self.parseDataAsArray(…)` → `DataParser().dictionariesFromData(…)`
+    - `self.parseDataAsDictionary(…)` → `DataParser().dictionaryFromData(…)`
+    - `self.parseEntitiesFromArray(…)` → `EntityParser().entitiesFromDictionaries(…)`
+    - `self.parseEntityFromDictionary(…)` → `EntityParser().entityFromDictionary(…)`
 
 ---
 

--- a/Jayme.xcodeproj/project.pbxproj
+++ b/Jayme.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		5163A0911CD7A2AF00B0EEEF /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0901CD7A2AF00B0EEEF /* Logger.swift */; };
 		5163A0931CD7A35F00B0EEEF /* Future.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0921CD7A35F00B0EEEF /* Future.swift */; };
 		5163A0951CD7A51800B0EEEF /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0941CD7A51800B0EEEF /* Result.swift */; };
+		5169EAE11CF780540047B572 /* EntityParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5169EAE01CF780540047B572 /* EntityParser.swift */; };
+		5169EAE31CF789370047B572 /* DataParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5169EAE21CF789370047B572 /* DataParser.swift */; };
 		516ECB0A1CD7AB6A0090A176 /* FakeHTTPResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB001CD7AB6A0090A176 /* FakeHTTPResponseParser.swift */; };
 		516ECB0B1CD7AB6A0090A176 /* TestingBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB011CD7AB6A0090A176 /* TestingBackend.swift */; };
 		516ECB0C1CD7AB6A0090A176 /* FakeURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB021CD7AB6A0090A176 /* FakeURLSession.swift */; };
@@ -89,6 +91,8 @@
 		5163A0901CD7A2AF00B0EEEF /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		5163A0921CD7A35F00B0EEEF /* Future.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Future.swift; sourceTree = "<group>"; };
 		5163A0941CD7A51800B0EEEF /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		5169EAE01CF780540047B572 /* EntityParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EntityParser.swift; sourceTree = "<group>"; };
+		5169EAE21CF789370047B572 /* DataParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataParser.swift; sourceTree = "<group>"; };
 		516ECB001CD7AB6A0090A176 /* FakeHTTPResponseParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeHTTPResponseParser.swift; sourceTree = "<group>"; };
 		516ECB011CD7AB6A0090A176 /* TestingBackend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestingBackend.swift; sourceTree = "<group>"; };
 		516ECB021CD7AB6A0090A176 /* FakeURLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeURLSession.swift; sourceTree = "<group>"; };
@@ -152,8 +156,8 @@
 		5163A00B1CD7873800B0EEEF /* Jayme */ = {
 			isa = PBXGroup;
 			children = (
+				511019221CF3532600380481 /* Compatibility.swift */,
 				5163A0681CD78A6300B0EEEF /* Model */,
-				5163A06F1CD78ABF00B0EEEF /* Helpers */,
 			);
 			path = Jayme;
 			sourceTree = "<group>";
@@ -180,6 +184,9 @@
 		5163A0681CD78A6300B0EEEF /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				5163A0701CD78AC700B0EEEF /* Async Util */,
+				5163A0711CD78AD300B0EEEF /* Logger */,
+				5169EADF1CF780300047B572 /* Parsers */,
 				5163A0691CD78A8000B0EEEF /* Backend */,
 				5163A06C1CD78A9B00B0EEEF /* Repositories */,
 				5163A06B1CD78A8F00B0EEEF /* Entities */,
@@ -238,16 +245,6 @@
 			name = HTTP;
 			sourceTree = "<group>";
 		};
-		5163A06F1CD78ABF00B0EEEF /* Helpers */ = {
-			isa = PBXGroup;
-			children = (
-				5163A0701CD78AC700B0EEEF /* Async Util */,
-				5163A0711CD78AD300B0EEEF /* Logger */,
-				511019221CF3532600380481 /* Compatibility.swift */,
-			);
-			name = Helpers;
-			sourceTree = "<group>";
-		};
 		5163A0701CD78AC700B0EEEF /* Async Util */ = {
 			isa = PBXGroup;
 			children = (
@@ -263,6 +260,15 @@
 				5163A0901CD7A2AF00B0EEEF /* Logger.swift */,
 			);
 			name = Logger;
+			sourceTree = "<group>";
+		};
+		5169EADF1CF780300047B572 /* Parsers */ = {
+			isa = PBXGroup;
+			children = (
+				5169EAE21CF789370047B572 /* DataParser.swift */,
+				5169EAE01CF780540047B572 /* EntityParser.swift */,
+			);
+			name = Parsers;
 			sourceTree = "<group>";
 		};
 		516ECB141CD7AB6E0090A176 /* Helpers */ = {
@@ -465,6 +471,7 @@
 				5189519E1CD91DEE00089906 /* UserRepository.swift in Sources */,
 				5163A0811CD79C6300B0EEEF /* PagedRepository.swift in Sources */,
 				5163A0791CD7967900B0EEEF /* JaymeError.swift in Sources */,
+				5169EAE31CF789370047B572 /* DataParser.swift in Sources */,
 				518951A71CD924A100089906 /* Post.swift in Sources */,
 				5163A0951CD7A51800B0EEEF /* Result.swift in Sources */,
 				5163A08F1CD7A1E800B0EEEF /* PageInfo.swift in Sources */,
@@ -477,6 +484,7 @@
 				5163A07B1CD7970200B0EEEF /* HTTPResponseParser.swift in Sources */,
 				5163A0911CD7A2AF00B0EEEF /* Logger.swift in Sources */,
 				5163A0361CD7879900B0EEEF /* AppDelegate.swift in Sources */,
+				5169EAE11CF780540047B572 /* EntityParser.swift in Sources */,
 				518951AB1CD928D300089906 /* PostTableViewCell.swift in Sources */,
 				5163A0851CD7A01500B0EEEF /* DictionaryInitializable.swift in Sources */,
 				5163A0771CD7960800B0EEEF /* NSURLSessionBackendConfiguration.swift in Sources */,

--- a/Jayme.xcodeproj/project.pbxproj
+++ b/Jayme.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 		5163A07B1CD7970200B0EEEF /* HTTPResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A07A1CD7970200B0EEEF /* HTTPResponseParser.swift */; };
 		5163A07D1CD797E800B0EEEF /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A07C1CD797E800B0EEEF /* Repository.swift */; };
 		5163A07F1CD79A3B00B0EEEF /* CRUDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A07E1CD79A3B00B0EEEF /* CRUDRepository.swift */; };
-		5163A0811CD79C6300B0EEEF /* ServerPagedRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0801CD79C6300B0EEEF /* ServerPagedRepository.swift */; };
+		5163A0811CD79C6300B0EEEF /* PagedRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0801CD79C6300B0EEEF /* PagedRepository.swift */; };
 		5163A0831CD79FAB00B0EEEF /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0821CD79FAB00B0EEEF /* Identifiable.swift */; };
 		5163A0851CD7A01500B0EEEF /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0841CD7A01500B0EEEF /* DictionaryInitializable.swift */; };
 		5163A0871CD7A0DB00B0EEEF /* DictionaryRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0861CD7A0DB00B0EEEF /* DictionaryRepresentable.swift */; };
@@ -34,7 +34,7 @@
 		516ECB0C1CD7AB6A0090A176 /* FakeURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB021CD7AB6A0090A176 /* FakeURLSession.swift */; };
 		516ECB0D1CD7AB6A0090A176 /* HTTPResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB031CD7AB6A0090A176 /* HTTPResponseParserTests.swift */; };
 		516ECB0E1CD7AB6A0090A176 /* NSURLSessionBackendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB041CD7AB6A0090A176 /* NSURLSessionBackendTests.swift */; };
-		516ECB0F1CD7AB6A0090A176 /* ServerPagedRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB051CD7AB6A0090A176 /* ServerPagedRepositoryTests.swift */; };
+		516ECB0F1CD7AB6A0090A176 /* PagedRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB051CD7AB6A0090A176 /* PagedRepositoryTests.swift */; };
 		516ECB101CD7AB6A0090A176 /* CRUDRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB061CD7AB6A0090A176 /* CRUDRepositoryTests.swift */; };
 		516ECB111CD7AB6A0090A176 /* TestDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB071CD7AB6A0090A176 /* TestDocument.swift */; };
 		516ECB121CD7AB6A0090A176 /* TestDocumentPagedRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB081CD7AB6A0090A176 /* TestDocumentPagedRepository.swift */; };
@@ -79,7 +79,7 @@
 		5163A07A1CD7970200B0EEEF /* HTTPResponseParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPResponseParser.swift; sourceTree = "<group>"; };
 		5163A07C1CD797E800B0EEEF /* Repository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 		5163A07E1CD79A3B00B0EEEF /* CRUDRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CRUDRepository.swift; sourceTree = "<group>"; };
-		5163A0801CD79C6300B0EEEF /* ServerPagedRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerPagedRepository.swift; sourceTree = "<group>"; };
+		5163A0801CD79C6300B0EEEF /* PagedRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagedRepository.swift; sourceTree = "<group>"; };
 		5163A0821CD79FAB00B0EEEF /* Identifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		5163A0841CD7A01500B0EEEF /* DictionaryInitializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryInitializable.swift; sourceTree = "<group>"; };
 		5163A0861CD7A0DB00B0EEEF /* DictionaryRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryRepresentable.swift; sourceTree = "<group>"; };
@@ -94,7 +94,7 @@
 		516ECB021CD7AB6A0090A176 /* FakeURLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeURLSession.swift; sourceTree = "<group>"; };
 		516ECB031CD7AB6A0090A176 /* HTTPResponseParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPResponseParserTests.swift; sourceTree = "<group>"; };
 		516ECB041CD7AB6A0090A176 /* NSURLSessionBackendTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLSessionBackendTests.swift; sourceTree = "<group>"; };
-		516ECB051CD7AB6A0090A176 /* ServerPagedRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerPagedRepositoryTests.swift; sourceTree = "<group>"; };
+		516ECB051CD7AB6A0090A176 /* PagedRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagedRepositoryTests.swift; sourceTree = "<group>"; };
 		516ECB061CD7AB6A0090A176 /* CRUDRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CRUDRepositoryTests.swift; sourceTree = "<group>"; };
 		516ECB071CD7AB6A0090A176 /* TestDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDocument.swift; sourceTree = "<group>"; };
 		516ECB081CD7AB6A0090A176 /* TestDocumentPagedRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDocumentPagedRepository.swift; sourceTree = "<group>"; };
@@ -223,7 +223,7 @@
 			children = (
 				5163A07C1CD797E800B0EEEF /* Repository.swift */,
 				5163A07E1CD79A3B00B0EEEF /* CRUDRepository.swift */,
-				5163A0801CD79C6300B0EEEF /* ServerPagedRepository.swift */,
+				5163A0801CD79C6300B0EEEF /* PagedRepository.swift */,
 				5163A08E1CD7A1E800B0EEEF /* PageInfo.swift */,
 			);
 			name = Repositories;
@@ -284,7 +284,7 @@
 				516ECB041CD7AB6A0090A176 /* NSURLSessionBackendTests.swift */,
 				518CEA3E1CD8DD5900A4CA06 /* PageInfoTests.swift */,
 				516ECB061CD7AB6A0090A176 /* CRUDRepositoryTests.swift */,
-				516ECB051CD7AB6A0090A176 /* ServerPagedRepositoryTests.swift */,
+				516ECB051CD7AB6A0090A176 /* PagedRepositoryTests.swift */,
 				516ECB031CD7AB6A0090A176 /* HTTPResponseParserTests.swift */,
 			);
 			name = Tests;
@@ -463,7 +463,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5189519E1CD91DEE00089906 /* UserRepository.swift in Sources */,
-				5163A0811CD79C6300B0EEEF /* ServerPagedRepository.swift in Sources */,
+				5163A0811CD79C6300B0EEEF /* PagedRepository.swift in Sources */,
 				5163A0791CD7967900B0EEEF /* JaymeError.swift in Sources */,
 				518951A71CD924A100089906 /* Post.swift in Sources */,
 				5163A0951CD7A51800B0EEEF /* Result.swift in Sources */,
@@ -506,7 +506,7 @@
 				516ECB111CD7AB6A0090A176 /* TestDocument.swift in Sources */,
 				516ECB0B1CD7AB6A0090A176 /* TestingBackend.swift in Sources */,
 				516ECB121CD7AB6A0090A176 /* TestDocumentPagedRepository.swift in Sources */,
-				516ECB0F1CD7AB6A0090A176 /* ServerPagedRepositoryTests.swift in Sources */,
+				516ECB0F1CD7AB6A0090A176 /* PagedRepositoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Jayme/Compatibility.swift
+++ b/Jayme/Compatibility.swift
@@ -44,3 +44,7 @@ typealias ServerRepository = CRUDRepository
 /// StringDictionary -> [String: AnyObject]
 @available(*, unavailable, renamed = "[String: AnyObject]")
 typealias StringDictionary = [String: AnyObject]
+
+/// ServerPagedRepository -> PagedRepository
+@available(*, unavailable, renamed = "PagedRepository")
+typealias ServerPagedRepository = PagedRepository

--- a/Jayme/DataParser.swift
+++ b/Jayme/DataParser.swift
@@ -1,0 +1,59 @@
+// Jayme
+// DataParser.swift
+//
+// Copyright (c) 2016 Inaka - http://inaka.net/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// Provides functions to be used within a repository for converting Dictionaries into Entities an chaining their results with `Future` convenient functions (e.g. `map` and `andThen`
+public class DataParser {
+    
+    /// Returns a `Future` containing a dictionary initialized with the optional data passed by parameter, or `JaymeError.BadResponse` if the dictionary can't be initialized from that data.
+    public func dictionaryFromData(maybeData: NSData?) -> Future<[String: AnyObject], JaymeError> {
+        return Future() { completion in
+            guard let
+                data = maybeData,
+                result = try? NSJSONSerialization.JSONObjectWithData(data, options: .AllowFragments),
+                dictionary = result as? [String: AnyObject]
+                else {
+                    completion(.Failure(.BadResponse))
+                    return
+            }
+            completion(.Success(dictionary))
+        }
+    }
+    
+     /// Returns a `Future` containing an array of dictionaries initialized with the optional data passed by parameter, or `JaymeError.BadResponse` if the array can't be initialized from that data.
+    public func dictionariesFromData(maybeData: NSData?) -> Future<[[String: AnyObject]], JaymeError> {
+        return Future() { completion in
+            guard let
+                data = maybeData,
+                result = try? NSJSONSerialization.JSONObjectWithData(data, options: .AllowFragments),
+                array = result as? [[String: AnyObject]]
+                else {
+                    completion(.Failure(.BadResponse))
+                    return
+            }
+            completion(.Success(array))
+        }
+    }
+    
+}

--- a/Jayme/EntityParser.swift
+++ b/Jayme/EntityParser.swift
@@ -1,0 +1,48 @@
+// Jayme
+// EntityParser.swift
+//
+// Copyright (c) 2016 Inaka - http://inaka.net/
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+/// Provides functions to be used within a repository for converting Dictionaries into Entities an chaining their results with `Future` convenient functions (e.g. `map` and `andThen`)
+public class EntityParser<EntityType: DictionaryInitializable> {
+    
+    /// Returns a `Future` containing an entity initialized with the dictionary value passed by parameter, or `JaymeError.ParsingError` if the entity could not be initialized.
+    public func entityFromDictionary(dictionary: [String: AnyObject]) -> Future<EntityType, JaymeError> {
+        return Future() { completion in
+            guard let entity = try? EntityType(dictionary: dictionary) else {
+                completion(.Failure(.ParsingError))
+                return
+            }
+            completion(.Success(entity))
+        }
+    }
+    
+    /// Returns a `Future` containing an array of those entities that could be parsed from the `dictionaries` array passed by parameter.
+    public func entitiesFromDictionaries(dictionaries: [[String: AnyObject]]) -> Future<[EntityType], JaymeError> {
+        return Future() { completion in
+            let entities = dictionaries.flatMap({ try? EntityType(dictionary: $0) })
+            completion(.Success(entities))
+        }
+    }
+    
+}

--- a/Jayme/PagedRepository.swift
+++ b/Jayme/PagedRepository.swift
@@ -1,5 +1,5 @@
 // Jayme
-// ServerPagedRepository.swift
+// PagedRepository.swift
 //
 // Copyright (c) 2016 Inaka - http://inaka.net/
 //
@@ -24,12 +24,12 @@
 import Foundation
 
 /// Adds supplies onto CRUDRepository for pagination management, based on Grape conventions (https://github.com/davidcelis/api-pagination)
-public protocol ServerPagedRepository: CRUDRepository {
+public protocol PagedRepository: CRUDRepository {
     /// Indicates the number of entities to be fetched per page
     var pageSize: Int { get }
 }
 
-public extension ServerPagedRepository {
+public extension PagedRepository {
     
     /// Returns a `Future` containing a tuple with an array of all the `Entity` objects in the repository and a PageInfo object with pagination-related data
     public func findByPage(pageNumber pageNumber: Int) -> Future<([EntityType], PageInfo), JaymeError> {

--- a/Jayme/PagedRepository.swift
+++ b/Jayme/PagedRepository.swift
@@ -23,10 +23,11 @@
 
 import Foundation
 
-/// Adds supplies onto CRUDRepository for pagination management, based on Grape conventions (https://github.com/davidcelis/api-pagination)
-public protocol PagedRepository: CRUDRepository {
+/// Provides a Repository with read functionality with pagination, based on Grape conventions (https://github.com/davidcelis/api-pagination)
+public protocol PagedRepository: Repository {
     /// Indicates the number of entities to be fetched per page
     var pageSize: Int { get }
+    var backend: NSURLSessionBackend { get }
 }
 
 public extension PagedRepository {
@@ -38,10 +39,10 @@ public extension PagedRepository {
         let future = self.backend.futureForPath(path, method: .GET, parameters: nil)
             .andThen {
                 pageInfo = $0.1
-                return self.parseDataAsArray($0.0)
+                return DataParser().dictionariesFromData($0.0)
             }
             .andThen {
-                self.parseEntitiesFromArray($0)
+                EntityParser<EntityType>().entitiesFromDictionaries($0)
             }
             .map {
                 return ($0, pageInfo!)
@@ -50,4 +51,3 @@ public extension PagedRepository {
     }
     
 }
-

--- a/Jayme/Repository.swift
+++ b/Jayme/Repository.swift
@@ -23,9 +23,10 @@
 
 import Foundation
 
+
 /// Abstraction for representing a Repository of a certain kind of Entities
 public protocol Repository {
-    
+        
     /// The Entity type going to be used in the Repository
     /// Classes conforming to `Repository` must tie this associated type to a concrete type
     associatedtype EntityType: Identifiable, DictionaryInitializable, DictionaryRepresentable

--- a/JaymeTests/PagedRepositoryTests.swift
+++ b/JaymeTests/PagedRepositoryTests.swift
@@ -1,5 +1,5 @@
 // Jayme
-// ServerPagedRepositoryTests.swift
+// PagedRepositoryTests.swift
 //
 // Copyright (c) 2016 Inaka - http://inaka.net/
 //
@@ -24,7 +24,7 @@
 import XCTest
 @testable import Jayme
 
-class ServerPagedRepositoryTests: XCTestCase {
+class PagedRepositoryTests: XCTestCase {
 
     var backend: TestingBackend!
     var repository: TestDocumentPagedRepository!
@@ -41,7 +41,7 @@ class ServerPagedRepositoryTests: XCTestCase {
 
 // MARK: - Calls To Backend Tests
 
-extension ServerPagedRepositoryTests {
+extension PagedRepositoryTests {
     
     func testFindAllCall() {
         self.repository.findByPage(pageNumber: 1)
@@ -52,7 +52,7 @@ extension ServerPagedRepositoryTests {
 
 // MARK: - Response Parsing Tests
 
-extension ServerPagedRepositoryTests {
+extension PagedRepositoryTests {
 
     // Check the PageInfo object that is returned
     func testFindAllSuccessCallback() {

--- a/JaymeTests/TestDocumentPagedRepository.swift
+++ b/JaymeTests/TestDocumentPagedRepository.swift
@@ -24,7 +24,7 @@
 import Foundation
 @testable import Jayme
 
-class TestDocumentPagedRepository: ServerPagedRepository {
+class TestDocumentPagedRepository: PagedRepository {
     typealias EntityType = TestDocument
     let name = "documents"
     let backend: NSURLSessionBackend

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ There's no concrete definition of any Entity in Jayme. You define them. The only
 
 ### The Inaka Standard
 
-Jayme comes with a default standard implementation, which is based on the conventions that we normally follow at [Inaka](http://inaka.net/). It involves `NSURLSessionBackend`, `CRUDRepository` and `ServerPagedRepository`.
+Jayme comes with a default standard implementation, which is based on the conventions that we normally follow at [Inaka](http://inaka.net/). It involves the `NSURLSessionBackend` class, and the `CRUDRepository` and `PagedRepository` protocols.
 
 You can either leverage these defaults or implement your own repositories and backends by conforming directly to the base `Repository` and `Backend` protocols provided by Jayme's foundation, skipping any of the aforementioned classes.
 
@@ -89,17 +89,17 @@ These default interfaces are briefly described below:
 
 #### *CRUDRepository*
 
-- This protocol provides a Repository with convenient CRUD-like functions that are already implemented and ready to be used in any Repository that conforms to it, such as:
+- This protocol provides convenient CRUD-like functions that are already implemented and ready to be used in any Repository that conforms to it, such as:
   - `findAll()` for fetching all the Entities from the Repository.
   - `findByID(id)` for fetching a specific Entity matching a given `id`.
   - `create(entity)` for creating a new Entity in the Repository.
   - `update(entity)` for updating an existing Entity with its new values.
   - `delete(entity)` for deleting an existing Entity from the Repository.
 
-#### *ServerPagedRepository*
+#### *PagedRepository*
 
-- This protocol adds pagination-related functionality to the already known `CRUDRepository`. The extra function to make use of is:
-  - `findByPage(pageNumber)` for fetching a fixed amount of Entities from the Repository, corresponding to a certain page number. The amount of Entities fetched per page is configured in your concrete repository by providing a `pageSize` property.
+- This protocol provides convenient functionality for reading entities in a paginated manner. Any of your Repositories can conform to it and get this function by free:
+  - `findByPage(pageNumber)` for fetching a fixed amount of Entities from the Repository, corresponding to a certain page number. The amount of Entities fetched per page is configured in your concrete repository by providing a `pageSize` property. Besides the array containing entities, you get a `PageInfo` related object as well in return.
 - The followed pagination conventions have been based on [these standards](https://github.com/davidcelis/api-pagination).
 
 ### Your Own Standard


### PR DESCRIPTION
- Solves issue #20.
- `ServerPagedRepository` → `PagedRepository`.
- `PagedRepository` now inherits conformance directly from `Repository`, instead of passing through `CRUDRepository`.
- Plucked out convenience parsing functions from `CRUDRepository` into new separated classes named `DataParser` and `EntityParser`.
- Updated documentation.
