### PR TITLE
Pablo.issue22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,25 @@ All notable changes to this project will be documented in this file. `Jayme` a
 
 ## 2.0.0
 
+#### Repository related changes
+
 - `path` variable has been renamed to `name` in `Repository` protocol declaration. (Issue [#17](https://github.com/inaka/Jayme/issues/17))
-- `ServerBackend` protocol has been renamed to `NSURLSessionBackend`. (Issue [#18](https://github.com/inaka/Jayme/issues/18))
-- `ServerBackendConfiguration` has been renamed to `NSURLSessionBackendConfiguration`. (Issue [#18](https://github.com/inaka/Jayme/issues/18))
-- `ServerBackendError` has been renamed to `JaymeError`. (Issue [#21](https://github.com/inaka/Jayme/issues/21))
 - `ServerRepository` has been renamed to `CRUDRepository`. (Issue [#19](https://github.com/inaka/Jayme/issues/19))
-- `StringDictionary` typealias has been removed. (Issue [#28](https://github.com/inaka/Jayme/issues/28))
-- `init?(dictionary)` has been replaced by `init(dictionary) throws` in `DictionaryInitializable` protocol. (Issue [#25](https://github.com/inaka/Jayme/issues/25))
 - `PagedRepository` no longer conforms to `CRUDRepository` (ex `ServerRepository`); now it conforms directly to `Repository`. (Issue [#20](https://github.com/inaka/Jayme/issues/20))
 - Convenient parsing functions have been plucked out from `CRUDRepository` (ex `ServerRepository`) and put into new classes named `DataParser` and `EntityParser`.  (Issue [#20](https://github.com/inaka/Jayme/issues/20))
+
+#### Backend related changes
+
+- ServerBackend` protocol has been renamed to `NSURLSessionBackend`. (Issue [#18](https://github.com/inaka/Jayme/issues/18))
+- `ServerBackendConfiguration` has been renamed to `NSURLSessionBackendConfiguration`. (Issue [#18](https://github.com/inaka/Jayme/issues/18))
+- `ServerBackendError` has been renamed to `JaymeError`. (Issue [#21](https://github.com/inaka/Jayme/issues/21))
+
+#### Entity related changes
+
+- `init?(dictionary)` has been replaced by `init(dictionary) throws` in `DictionaryInitializable` protocol. (Issue [#25](https://github.com/inaka/Jayme/issues/25))
+- `StringDictionary` typealias has been removed. (Issue [#28](https://github.com/inaka/Jayme/issues/28))
+- `Identifier` typealias has been removed. (Issue [#22](https://github.com/inaka/Jayme/issues/22))
+- `id` variable in `Identifiable` protocol no longer works with `Identifier`. Now it uses an associated type (`IdentifierType`) for that. (Issue [#22](https://github.com/inaka/Jayme/issues/22))
 
 ---
 

--- a/Documentation/Jayme 2.0 Migration Guide.md
+++ b/Documentation/Jayme 2.0 Migration Guide.md
@@ -35,7 +35,7 @@ They are listed below:
   - You have to manually replace your `init?` initializers for every class or struct that conforms to `DictionaryInitializable` by its throwable equivalent.
   - You have to perform `{ throw JaymeError.ParsingError }` whenever you can't initialize a `DictionaryInitializable` object instead of performing `{ return nil }`.
 
-- `Identifier` typealias no longer exists. Now your entities can define their own identifier type.  (related issue: [#22](https://github.com/inaka/Jayme/issues/22))
+- `Identifier` typealias no longer exists. Now your entities define their own identifier type.  (related issue: [#22](https://github.com/inaka/Jayme/issues/22))
 
   - You have to change every `Identifier` appearance and replace it by a concrete type you need to use (e.g. `String`, `Int`, or your own, as long as it conforms to `CustomStringConvertible`). This change should be suggested by the compiler.
 

--- a/Documentation/Jayme 2.0 Migration Guide.md
+++ b/Documentation/Jayme 2.0 Migration Guide.md
@@ -29,10 +29,27 @@ They are listed below:
 
 - `path` variable has been renamed to `name` in `Repository` protocol declaration. (related issue: [#17](https://github.com/inaka/Jayme/issues/17))
   - You have to change every `path` appearance in your Repositories by using `name` instead.
+
 - `init?(dictionary: StringDictionary)` has been replaced by `init(dictionary: [String: AnyObject]) throws`. (related issues: [#25](https://github.com/inaka/Jayme/issues/25), [#28](https://github.com/inaka/Jayme/issues/28))
   - `StringDictionary` → `[String: AnyObject]` replacements should be suggested by the compiler.
   - You have to manually replace your `init?` initializers for every class or struct that conforms to `DictionaryInitializable` by its throwable equivalent.
   - You have to perform `{ throw JaymeError.ParsingError }` whenever you can't initialize a `DictionaryInitializable` object instead of performing `{ return nil }`.
+
+- `Identifier` typealias no longer exists. Now your entities can define their own identifier type.  (related issue: [#22](https://github.com/inaka/Jayme/issues/22))
+
+  - You have to change every `Identifier` appearance and replace it by a concrete type you need to use (e.g. `String`, `Int`, or your own, as long as it conforms to `CustomStringConvertible`). This change should be suggested by the compiler.
+
+  - However, since by default `String` does not conform to `CustomStringConvertible`, you'd probably want to add this extension to your code: 
+
+    - ```swift
+      extension String: CustomStringConvertible {
+          public var description: String {
+              return self
+          }
+      }
+      ```
+
+
 
 - Convenient parsing functions under one of the extensions in `ServerRepository` (now `CRUDRepository`) have been moved into separated new classes called `DataParser` and `EntityParser`. If you were calling those functions somewhere in your code, you have to change their calls to use those parsers classes instead of your repository itself. (related issue: [#20](https://github.com/inaka/Jayme/issues/20))
   - Possible replacements are:

--- a/Example/Extensions.swift
+++ b/Example/Extensions.swift
@@ -1,5 +1,5 @@
-// Jayme
-// TestDocument.swift
+// JaymeExample
+// Extensions.swift
 //
 // Copyright (c) 2016 Inaka - http://inaka.net/
 //
@@ -22,26 +22,9 @@
 // THE SOFTWARE.
 
 import Foundation
-@testable import Jayme
 
-struct TestDocument: Identifiable {
-    let id: String
-    let name: String
-}
-
-extension TestDocument: DictionaryInitializable, DictionaryRepresentable {
-    
-    init(dictionary: [String: AnyObject]) throws {
-        guard let
-            id = dictionary["id"] as? String,
-            name = dictionary["name"] as? String
-            else { throw JaymeError.ParsingError }
-        self.id = id
-        self.name = name
+extension String: CustomStringConvertible {
+    public var description: String {
+        return self
     }
-    
-    var dictionaryValue: [String : AnyObject] {
-        return ["id": self.id, "name": self.name]
-    }
-    
 }

--- a/Example/Identifier.swift
+++ b/Example/Identifier.swift
@@ -1,5 +1,5 @@
-// Jayme
-// TestDocument.swift
+// JaymeExample
+// Identifier.swift
 //
 // Copyright (c) 2016 Inaka - http://inaka.net/
 //
@@ -22,26 +22,20 @@
 // THE SOFTWARE.
 
 import Foundation
-@testable import Jayme
 
-struct TestDocument: Identifiable {
-    let id: String
-    let name: String
+/// Enumeration for identifying an object via either a local ID or a server-defined ID, and being able to distinguish which scenario it corresponds to.
+enum Identifier {
+    case Local(String)
+    case Server(String)
 }
 
-extension TestDocument: DictionaryInitializable, DictionaryRepresentable {
-    
-    init(dictionary: [String: AnyObject]) throws {
-        guard let
-            id = dictionary["id"] as? String,
-            name = dictionary["name"] as? String
-            else { throw JaymeError.ParsingError }
-        self.id = id
-        self.name = name
+extension Identifier: CustomStringConvertible {
+    var description: String {
+        switch self {
+        case .Local(let id):
+            return "local_\(id)"
+        case .Server(let id):
+            return id
+        }
     }
-    
-    var dictionaryValue: [String : AnyObject] {
-        return ["id": self.id, "name": self.name]
-    }
-    
 }

--- a/Example/Post.swift
+++ b/Example/Post.swift
@@ -25,7 +25,7 @@ import Foundation
 
 struct Post: Identifiable {
     let id: Identifier
-    let authorID: Identifier
+    let authorID: String
     let title: String
     let abstract: String
     let date: NSDate
@@ -42,7 +42,7 @@ extension Post: DictionaryInitializable, DictionaryRepresentable {
             dateString = dictionary["date"] as? String,
             date = dateString.toDate()
             else { throw JaymeError.ParsingError }
-        self.id = id
+        self.id = .Server(id)
         self.authorID = authorID
         self.title = title
         self.abstract = abstract
@@ -51,7 +51,7 @@ extension Post: DictionaryInitializable, DictionaryRepresentable {
     
     var dictionaryValue: [String: AnyObject] {
         return [
-            "id": self.id,
+            "id": "\(self.id)",
             "author_id": self.authorID,
             "title": self.title,
             "abstract": self.abstract,

--- a/Example/Post.swift
+++ b/Example/Post.swift
@@ -24,7 +24,7 @@
 import Foundation
 
 struct Post: Identifiable {
-    let id: Identifier
+    let id: PostIdentifier
     let authorID: String
     let title: String
     let abstract: String

--- a/Example/PostIdentifier.swift
+++ b/Example/PostIdentifier.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-/// Enumeration for identifying an object via either a local ID or a server-defined ID, and being able to distinguish which scenario it corresponds to.
+/// Enumeration for identifying a Post via either a local ID or a server-defined ID, and being able to distinguish which scenario it corresponds to.
 enum PostIdentifier {
     case Local(String)
     case Server(String)

--- a/Example/PostIdentifier.swift
+++ b/Example/PostIdentifier.swift
@@ -1,5 +1,5 @@
 // JaymeExample
-// Identifier.swift
+// PostIdentifier.swift
 //
 // Copyright (c) 2016 Inaka - http://inaka.net/
 //
@@ -24,12 +24,12 @@
 import Foundation
 
 /// Enumeration for identifying an object via either a local ID or a server-defined ID, and being able to distinguish which scenario it corresponds to.
-enum Identifier {
+enum PostIdentifier {
     case Local(String)
     case Server(String)
 }
 
-extension Identifier: CustomStringConvertible {
+extension PostIdentifier: CustomStringConvertible {
     var description: String {
         switch self {
         case .Local(let id):

--- a/Example/User.swift
+++ b/Example/User.swift
@@ -24,7 +24,7 @@
 import Foundation
 
 struct User: Identifiable {
-    let id: Identifier
+    let id: String
     let name: String
     let email: String
 }

--- a/Jayme.xcodeproj/project.pbxproj
+++ b/Jayme.xcodeproj/project.pbxproj
@@ -53,7 +53,7 @@
 		518951AD1CD92CA500089906 /* posts in Resources */ = {isa = PBXBuildFile; fileRef = 518951AC1CD92CA500089906 /* posts */; };
 		518CEA3F1CD8DD5900A4CA06 /* PageInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518CEA3E1CD8DD5900A4CA06 /* PageInfoTests.swift */; };
 		51F6D1C91CF89B2900E998F0 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F6D1C81CF89B2900E998F0 /* Extensions.swift */; };
-		51F6D1CB1CF89B9B00E998F0 /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F6D1CA1CF89B9B00E998F0 /* Identifier.swift */; };
+		51F6D1CB1CF89B9B00E998F0 /* PostIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F6D1CA1CF89B9B00E998F0 /* PostIdentifier.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -117,7 +117,7 @@
 		518951AC1CD92CA500089906 /* posts */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = posts; sourceTree = "<group>"; };
 		518CEA3E1CD8DD5900A4CA06 /* PageInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageInfoTests.swift; sourceTree = "<group>"; };
 		51F6D1C81CF89B2900E998F0 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-		51F6D1CA1CF89B9B00E998F0 /* Identifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Identifier.swift; sourceTree = "<group>"; };
+		51F6D1CA1CF89B9B00E998F0 /* PostIdentifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostIdentifier.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -373,7 +373,7 @@
 		51F6D1CC1CF89D0500E998F0 /* Identifiers */ = {
 			isa = PBXGroup;
 			children = (
-				51F6D1CA1CF89B9B00E998F0 /* Identifier.swift */,
+				51F6D1CA1CF89B9B00E998F0 /* PostIdentifier.swift */,
 				51F6D1C81CF89B2900E998F0 /* Extensions.swift */,
 			);
 			name = Identifiers;
@@ -504,7 +504,7 @@
 				5163A0771CD7960800B0EEEF /* NSURLSessionBackendConfiguration.swift in Sources */,
 				5163A0831CD79FAB00B0EEEF /* Identifiable.swift in Sources */,
 				5163A0871CD7A0DB00B0EEEF /* DictionaryRepresentable.swift in Sources */,
-				51F6D1CB1CF89B9B00E998F0 /* Identifier.swift in Sources */,
+				51F6D1CB1CF89B9B00E998F0 /* PostIdentifier.swift in Sources */,
 				5189519A1CD91CA500089906 /* UserTableViewCell.swift in Sources */,
 				5163A07F1CD79A3B00B0EEEF /* CRUDRepository.swift in Sources */,
 				518951A91CD9255800089906 /* PostRepository.swift in Sources */,

--- a/Jayme.xcodeproj/project.pbxproj
+++ b/Jayme.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		518951AB1CD928D300089906 /* PostTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518951AA1CD928D300089906 /* PostTableViewCell.swift */; };
 		518951AD1CD92CA500089906 /* posts in Resources */ = {isa = PBXBuildFile; fileRef = 518951AC1CD92CA500089906 /* posts */; };
 		518CEA3F1CD8DD5900A4CA06 /* PageInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518CEA3E1CD8DD5900A4CA06 /* PageInfoTests.swift */; };
+		51F6D1C91CF89B2900E998F0 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F6D1C81CF89B2900E998F0 /* Extensions.swift */; };
+		51F6D1CB1CF89B9B00E998F0 /* Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F6D1CA1CF89B9B00E998F0 /* Identifier.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -114,6 +116,8 @@
 		518951AA1CD928D300089906 /* PostTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostTableViewCell.swift; sourceTree = "<group>"; };
 		518951AC1CD92CA500089906 /* posts */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = posts; sourceTree = "<group>"; };
 		518CEA3E1CD8DD5900A4CA06 /* PageInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageInfoTests.swift; sourceTree = "<group>"; };
+		51F6D1C81CF89B2900E998F0 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
+		51F6D1CA1CF89B9B00E998F0 /* Identifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Identifier.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -299,6 +303,7 @@
 		518951931CD91B2900089906 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				51F6D1CC1CF89D0500E998F0 /* Identifiers */,
 				5189519C1CD91DE400089906 /* Entities */,
 				5189519B1CD91DDB00089906 /* Repositories */,
 			);
@@ -363,6 +368,15 @@
 				5189519F1CD91E3600089906 /* Controller */,
 			);
 			name = Source;
+			sourceTree = "<group>";
+		};
+		51F6D1CC1CF89D0500E998F0 /* Identifiers */ = {
+			isa = PBXGroup;
+			children = (
+				51F6D1CA1CF89B9B00E998F0 /* Identifier.swift */,
+				51F6D1C81CF89B2900E998F0 /* Extensions.swift */,
+			);
+			name = Identifiers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -490,9 +504,11 @@
 				5163A0771CD7960800B0EEEF /* NSURLSessionBackendConfiguration.swift in Sources */,
 				5163A0831CD79FAB00B0EEEF /* Identifiable.swift in Sources */,
 				5163A0871CD7A0DB00B0EEEF /* DictionaryRepresentable.swift in Sources */,
+				51F6D1CB1CF89B9B00E998F0 /* Identifier.swift in Sources */,
 				5189519A1CD91CA500089906 /* UserTableViewCell.swift in Sources */,
 				5163A07F1CD79A3B00B0EEEF /* CRUDRepository.swift in Sources */,
 				518951A91CD9255800089906 /* PostRepository.swift in Sources */,
+				51F6D1C91CF89B2900E998F0 /* Extensions.swift in Sources */,
 				5163A0891CD7A14400B0EEEF /* HTTPHeader.swift in Sources */,
 				5163A0731CD78B5E00B0EEEF /* Backend.swift in Sources */,
 				518951921CD91A6B00089906 /* UsersViewController.swift in Sources */,

--- a/Jayme/CRUDRepository.swift
+++ b/Jayme/CRUDRepository.swift
@@ -42,7 +42,7 @@ public extension CRUDRepository {
     
     /// Returns a `Future` containing the `Entity` matching the `id`.
     /// Watch out for a `.Failure` case with `EntityNotFound` error.
-    public func findByID(id: Identifier) -> Future<EntityType, JaymeError> {
+    public func findByID(id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
         let path = self.pathForID(id)
         return self.backend.futureForPath(path, method: .GET, parameters: nil)
             .andThen { DataParser().dictionaryFromData($0.0) }
@@ -72,8 +72,8 @@ public extension CRUDRepository {
     
     // MARK: - Private
     
-    private func pathForID(id: Identifier) -> Path {
-        return self.name + "/" + id
+    private func pathForID(id: EntityType.IdentifierType) -> Path {
+        return "\(self.name)/\(id)"
     }
     
 }

--- a/Jayme/Compatibility.swift
+++ b/Jayme/Compatibility.swift
@@ -48,3 +48,7 @@ typealias StringDictionary = [String: AnyObject]
 /// ServerPagedRepository -> PagedRepository
 @available(*, unavailable, renamed = "PagedRepository")
 typealias ServerPagedRepository = PagedRepository
+
+/// Identifier -> String
+@available(*, unavailable, message = "Replace `Identifier` with any type that conforms to `CustomStringConvertible`.")
+typealias Identifier = String

--- a/Jayme/Compatibility.swift
+++ b/Jayme/Compatibility.swift
@@ -49,6 +49,6 @@ typealias StringDictionary = [String: AnyObject]
 @available(*, unavailable, renamed = "PagedRepository")
 typealias ServerPagedRepository = PagedRepository
 
-/// Identifier -> String
+/// Identifier -> IdentifierType: CustomStringConvertible
 @available(*, unavailable, message = "Replace `Identifier` with any type that conforms to `CustomStringConvertible`.")
 typealias Identifier = String

--- a/Jayme/Identifiable.swift
+++ b/Jayme/Identifiable.swift
@@ -26,7 +26,7 @@ import Foundation
 /// Protocol for identifying entities via an `id` property.
 public protocol Identifiable {
     
-    /// An associated type that your identifiers will work with (e.g. String).
+    /// An associated type which identifiers for the EntityType conforming to this protocol will work with (e.g. String).
     associatedtype IdentifierType: CustomStringConvertible
     
     /// The property for identifying your entity.

--- a/Jayme/Identifiable.swift
+++ b/Jayme/Identifiable.swift
@@ -23,9 +23,13 @@
 
 import Foundation
 
-public typealias Identifier = String
-
 /// Protocol for identifying entities via an `id` property.
 public protocol Identifiable {
-    var id: Identifier { get }
+    
+    /// An associated type that your identifiers will work with (e.g. String).
+    associatedtype IdentifierType: CustomStringConvertible
+    
+    /// The property for identifying your entity.
+    var id: IdentifierType { get }
+    
 }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Jayme takes a flexible approach regarding identifiers. As of Jayme 2.0, identifi
 There are some scenarios where you might want to handle local identifiers vs. server identifiers. For those, you might want to take a look at the example project. There are two entities defined there:
 
 - `User`, which uses `String` for its identifier.
-- `Post`, which uses a custom `Identifier` `enum` for dealing with the aforementioned scenario.
+- `Post`, which uses a custom `PostIdentifier`  enumeration for dealing with the aforementioned issue.
 
 
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ There's no concrete definition of any Entity in Jayme. You define them. The only
   - The other way around, to allow the entity to be represented with a dictionary (parsed out).
   - Used in `CRUDRepository` by `create`, `update` and `delete` methods.
 
+
+
+### Identifiers
+
+Jayme takes a flexible approach regarding identifiers. As of Jayme 2.0, identifiers are not tied to any concrete type, it's up to you to define which kind of identifier each of your entity types will use. You can have entities using `Int`, other entities using `String`, all of your entities using the same type, using your custom types, or whatever best fit your needs.
+
+There are some scenarios where you might want to handle local identifiers vs. server identifiers. For those, you might want to take a look at the example project. There are two entities defined there:
+
+- `User`, which uses `String` for its identifier.
+- `Post`, which uses a custom `Identifier` `enum` for dealing with the aforementioned scenario.
+
+
+
 ### The Inaka Standard
 
 Jayme comes with a default standard implementation, which is based on the conventions that we normally follow at [Inaka](http://inaka.net/). It involves the `NSURLSessionBackend` class, and the `CRUDRepository` and `PagedRepository` protocols.
@@ -129,7 +142,7 @@ import Foundation
 import SwiftyJSON
 
 struct User: Identifiable {
-    let id: Identifier
+    let id: String
     let name: String
     let email: String
 }
@@ -239,8 +252,8 @@ import Foundation
 import SwifyJSON
 
 struct Post: Identifiable {
-    let id: Identifier
-    let authorID: Identifier
+    let id: String
+    let authorID: String
     let content: String
 }
 
@@ -278,7 +291,7 @@ class PostRepository: CRUDRepository {
     let backend = NSURLSessionBackend()
     let name = "posts"
     
-    func findPostsHavingAuthorID(authorID: Identifier) -> Future<[Post], JaymeError> {
+    func findPostsHavingAuthorID(authorID: String) -> Future<[Post], JaymeError> {
         // Server-side documentation states that Posts by AuthorID are found in the "/posts/:authorID" path
         let path = self.name + "/" + authorID
         return self.backend.futureForPath(path, method: .GET, parameters: nil)


### PR DESCRIPTION
- Solves the controversial issue #22 with the latest proposed solution.
- `Identifier` typealias has been removed.
- `Identifiable` protocol now uses an associated type (`IdentifierType`) for its `id` property. 
- Updated documentation accordingly.
- Enhanced change log, grouping changes by sections.
