### PR TITLE
pablo.issue24

### DIFF
--- a/Jayme/CRUDRepository.swift
+++ b/Jayme/CRUDRepository.swift
@@ -66,7 +66,7 @@ public extension CRUDRepository {
     /// Deletes the entity from the repository. Returns a `Future` with the `Void` result or a `JaymeError`
     public func delete(entity: EntityType) -> Future<Void, JaymeError> {
         let path = self.pathForID(entity.id)
-        return self.backend.futureForPath(path, method: .DELETE, parameters: entity.dictionaryValue)
+        return self.backend.futureForPath(path, method: .DELETE, parameters: nil)
             .map { _ in return }
     }
     

--- a/JaymeTests/CRUDRepositoryTests.swift
+++ b/JaymeTests/CRUDRepositoryTests.swift
@@ -89,13 +89,6 @@ extension CRUDRepositoryTests {
         self.repository.delete(document)
         XCTAssertEqual(self.backend.path, "documents/123")
         XCTAssertEqual(self.backend.method, .DELETE)
-        guard let
-            id = self.backend.parameters?["id"] as? String,
-            name = self.backend.parameters?["name"] as? String else {
-                XCTFail("Wrong parameters"); return
-        }
-        XCTAssertEqual(id, "123")
-        XCTAssertEqual(name, "a")
     }
     
 }


### PR DESCRIPTION
- Solves issue #24.
- Not sending parameters anymore in `DELETE` call in `CRUDRepository` default implementation.
- Updated test accordingly.
- No documentation updates required, since this isn't a API-breaker change.
