### PR TITLE
Pablo.issue37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. `Jayme` a
 - `path` variable has been renamed to `name` in `Repository` protocol declaration. (Issue [#17](https://github.com/inaka/Jayme/issues/17))
 - `ServerRepository` has been renamed to `CRUDRepository`. (Issue [#19](https://github.com/inaka/Jayme/issues/19))
 - `PagedRepository` no longer conforms to `CRUDRepository` (ex `ServerRepository`); now it conforms directly to `Repository`. (Issue [#20](https://github.com/inaka/Jayme/issues/20))
+- `create(…)` and `update(…)` methods in `CRUDRepository` now return `Future<EntityType, JaymeError>` instead of `Future<Void, JaymeError>`, containing the created or updated entity. (Issue [#37](https://github.com/inaka/Jayme/issues/37))
 - Convenient parsing functions have been plucked out from `CRUDRepository` (ex `ServerRepository`) and put into new classes named `DataParser` and `EntityParser`.  (Issue [#20](https://github.com/inaka/Jayme/issues/20))
 
 #### Backend related changes

--- a/Jayme/CRUDRepository.swift
+++ b/Jayme/CRUDRepository.swift
@@ -49,21 +49,23 @@ public extension CRUDRepository {
             .andThen { EntityParser().entityFromDictionary($0) }
     }
     
-    /// Creates the entity in the repository. Returns a `Future` with the `Void` result or a `JaymeError`
-    public func create(entity: EntityType) -> Future<Void, JaymeError> {
+    /// Creates the entity in the repository. Returns a `Future` with the created entity or a `JaymeError`
+    public func create(entity: EntityType) -> Future<EntityType, JaymeError> {
         let path = self.pathForID(entity.id)
         return self.backend.futureForPath(path, method: .POST, parameters: entity.dictionaryValue)
-            .map { _ in return }
+            .andThen { DataParser().dictionaryFromData($0.0) }
+            .andThen { EntityParser().entityFromDictionary($0) }
     }
     
-    /// Updates the entity in the repository. Returns a `Future` with the `Void` result or a `JaymeError`
-    public func update(entity: EntityType) -> Future<Void, JaymeError> {
+    /// Updates the entity in the repository. Returns a `Future` with the updated entity or a `JaymeError`
+    public func update(entity: EntityType) -> Future<EntityType, JaymeError> {
         let path = self.pathForID(entity.id)
         return self.backend.futureForPath(path, method: .PUT, parameters: entity.dictionaryValue)
-            .map { _ in return }
+            .andThen { DataParser().dictionaryFromData($0.0) }
+            .andThen { EntityParser().entityFromDictionary($0) }
     }
     
-    /// Deletes the entity from the repository. Returns a `Future` with the `Void` result or a `JaymeError`
+    /// Deletes the entity from the repository. Returns a `Future` with a `Void` result or a `JaymeError`
     public func delete(entity: EntityType) -> Future<Void, JaymeError> {
         let path = self.pathForID(entity.id)
         return self.backend.futureForPath(path, method: .DELETE, parameters: nil)

--- a/JaymeTests/CRUDRepositoryTests.swift
+++ b/JaymeTests/CRUDRepositoryTests.swift
@@ -273,7 +273,9 @@ extension CRUDRepositoryTests {
         
         // Simulated completion
         self.backend.completion = { completion in
-            completion(.Success((nil, nil)))
+            let json = ["id": "1", "name": "a"]
+            let data = try! NSJSONSerialization.dataWithJSONObject(json, options: .PrettyPrinted)
+            completion(.Success((data, nil)))
         }
         
         let expectation = self.expectationWithDescription("Expected to get a success")
@@ -281,8 +283,10 @@ extension CRUDRepositoryTests {
         let document = TestDocument(id: "_", name: "_")
         let future = self.repository.create(document)
         future.start() { result in
-            guard case .Success = result
+            guard case .Success(let document) = result
                 else { XCTFail(); return }
+            XCTAssertEqual(document.id, "1")
+            XCTAssertEqual(document.name, "a")
             expectation.fulfill()
         }
         
@@ -319,7 +323,9 @@ extension CRUDRepositoryTests {
         
         // Simulated completion
         self.backend.completion = { completion in
-            completion(.Success((nil, nil)))
+            let json = ["id": "1", "name": "a"]
+            let data = try! NSJSONSerialization.dataWithJSONObject(json, options: .PrettyPrinted)
+            completion(.Success((data, nil)))
         }
         
         let expectation = self.expectationWithDescription("Expected to get a success")
@@ -327,8 +333,10 @@ extension CRUDRepositoryTests {
         let document = TestDocument(id: "_", name: "_")
         let future = self.repository.update(document)
         future.start() { result in
-            guard case .Success = result
+            guard case .Success(let document) = result
                 else { XCTFail(); return }
+            XCTAssertEqual(document.id, "1")
+            XCTAssertEqual(document.name, "a")
             expectation.fulfill()
         }
         


### PR DESCRIPTION
- Solves issue #37.
- Changed return type on `create(...)` and `update(...)` methods in `CRUDRepository`. Before: `Future<Void, JaymeError>`. Now: `Future<EntityType, JaymeError>`, returning parsed entity that comes from the backend instead of `Void`.
- Updated tests accordingly.
- Updated change log.
- No further updates required, since this isn't an API-breaker.
