### PR TITLE
Pablo.issue55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ All notable changes to this project will be documented in this file. `Jayme` a
 
 ### 2.x Releases
 
-- `2.0.x` Releases - [2.0.0](#200)
+- `2.0.x` Releases - [2.0.0](#200) | [2.0.1](#201)
 
 ### 1.x Releases
 
 - `1.0.x` Releases - [1.0.1](#101) | [1.0.2](#102) | [1.0.3](#103) | [1.0.4](#104) 
 
 ---
+
+## 2.0.1
+
+- Results from repositories are returned on the main thread. (Issue [#55](https://github.com/inaka/Jayme/issues/19))
 
 ## 2.0.0
 

--- a/Documentation/Jayme 2.0 Migration Guide.md
+++ b/Documentation/Jayme 2.0 Migration Guide.md
@@ -44,6 +44,9 @@ They are listed below:
     - `self.parseDataAsDictionary(…)` → `DataParser().dictionaryFromData(…)`
     - `self.parseEntitiesFromArray(…)` → `EntityParser().entitiesFromDictionaries(…)`
     - `self.parseEntityFromDictionary(…)` → `EntityParser().entityFromDictionary(…)`
+- Results from Repositories using `NSURLBackend` (ex `ServerBackend`) are now returned on the main thread, instead of on a background thread.
+  - This will not break your existing code, but it's strongly recommended that you remove any possible `dispatch_async(dispatch_get_main_queue()) { ... }` call that you could have performed within your ViewControllers when getting results back from any repository. These calls are unnecessary now.
+
 
 ---
 

--- a/Example/UserDetailViewController.swift
+++ b/Example/UserDetailViewController.swift
@@ -44,9 +44,7 @@ class UserDetailViewController: UIViewController {
             switch result {
             case .Success(let posts):
                 self.posts = posts
-                dispatch_async(dispatch_get_main_queue()) {
-                    self.tableView.reloadData()
-                }
+                self.tableView.reloadData()
             case .Failure(let error):
                 self.showAlertControllerForError(error)
             }

--- a/Example/UsersViewController.swift
+++ b/Example/UsersViewController.swift
@@ -46,9 +46,7 @@ class UsersViewController: UIViewController {
             switch result {
             case .Success(let users):
                 self.users = users
-                dispatch_async(dispatch_get_main_queue()) {
-                    self.tableView.reloadData()
-                }
+                self.tableView.reloadData()
             case .Failure(let error):
                 self.showAlertControllerForError(error)
             }

--- a/Jayme/NSURLSessionBackend.swift
+++ b/Jayme/NSURLSessionBackend.swift
@@ -52,13 +52,15 @@ public class NSURLSessionBackend: Backend {
             let task = self.session.dataTaskWithRequest(request) { data, response, error in
                 let response: FullHTTPResponse = (data, response, error)
                 let result = self.responseParser.parseResponse(response)
-                switch result {
-                case .Success(let maybeData, let pageInfo):
-                    Logger.sharedLogger.log("Jayme: Response #\(requestNumber) | Success")
-                    completion(.Success(maybeData, pageInfo))
-                case .Failure(let error):
-                    Logger.sharedLogger.log("Jayme: Response #\(requestNumber) | Failure, error: \(error)")
-                    completion(.Failure(error))
+                dispatch_async(dispatch_get_main_queue()) {
+                    switch result {
+                    case .Success(let maybeData, let pageInfo):
+                        Logger.sharedLogger.log("Jayme: Response #\(requestNumber) | Success")
+                        completion(.Success(maybeData, pageInfo))
+                    case .Failure(let error):
+                        Logger.sharedLogger.log("Jayme: Response #\(requestNumber) | Failure, error: \(error)")
+                        completion(.Failure(error))
+                    }
                 }
             }
             task.resume()


### PR DESCRIPTION
- Solves issue #55.
- Invoking **main thread** before calling completion handlers in `NSURLSessionBackend`.
- Users will no longer need to invoke the main thread within their view controllers.
- Updated documentation accordingly.
