### PR TITLE
CRUD Refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. `Jayme` a
 
 ### 3.x Releases
 
-- `3.0.x` releases - [3.0.0](#300)
+- `3.0.x` releases - [3.0.0](#300) - [3.1.0](#310)
 
 ### 2.x Releases
 
@@ -17,6 +17,10 @@ All notable changes to this project will be documented in this file. `Jayme` a
 - `1.0.x` Releases - [1.0.1](#101) | [1.0.2](#102) | [1.0.3](#103) | [1.0.4](#104) 
 
 ---
+
+## 3.1.0
+
+- `CRUDRepository` protocol no longer exists. Its functionalities have now been divided into four separate protocols: `Creatable`, `Readable`, `Updatable` and `Deletable`. (Issue [#84](https://github.com/inaka/Jayme/issues/84))
 
 ## 3.0.0
 

--- a/Example/Post.swift
+++ b/Example/Post.swift
@@ -28,7 +28,7 @@ struct Post: Identifiable {
     let date: Date
 }
 
-extension Post: DictionaryInitializable, DictionaryRepresentable {
+extension Post: DictionaryInitializable {
     
     init(dictionary: [String: Any]) throws {
         guard
@@ -44,16 +44,6 @@ extension Post: DictionaryInitializable, DictionaryRepresentable {
         self.title = title
         self.abstract = abstract
         self.date = date
-    }
-    
-    var dictionaryValue: [String: Any] {
-        return [
-            "id": "\(self.id)",
-            "author_id": self.authorId,
-            "title": self.title,
-            "abstract": self.abstract,
-            "date": self.date
-        ]
     }
     
 }

--- a/Example/User.swift
+++ b/Example/User.swift
@@ -26,7 +26,7 @@ struct User: Identifiable {
     let email: String
 }
 
-extension User: DictionaryInitializable, DictionaryRepresentable {
+extension User: DictionaryInitializable {
     
     init(dictionary: [String: Any]) throws {
         guard let
@@ -38,13 +38,5 @@ extension User: DictionaryInitializable, DictionaryRepresentable {
         self.name = name
         self.email = email
     }
-    
-    var dictionaryValue: [String: Any] {
-        return [
-            "id": self.id,
-            "name": self.name,
-            "email": self.email
-        ]
-    }
-    
+
 }

--- a/Example/UserRepository.swift
+++ b/Example/UserRepository.swift
@@ -20,7 +20,7 @@
 
 import Foundation
 
-class UserRepository: CRUDRepository {
+class UserRepository: Readable {
     
     typealias EntityType = User
     let backend: URLSessionBackend

--- a/Jayme.podspec
+++ b/Jayme.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Jayme"
-  s.version      = "3.0.0"
+  s.version      = "3.1.0"
   s.summary      = "An abstraction layer that eases RESTful interconnections in Swift"
   s.description  = <<-DESC
                    Jayme defines a neat architecture for REST management in your Swift code. The idea behind this library is to separate concerns: Your view controllers should handle neither networking code nor heavy business logic code, in order to stay lightweight. The library provides a neat API to deal with REST communication, as well as default implementations for basic CRUD functionality and pagination.

--- a/Jayme.xcodeproj/project.pbxproj
+++ b/Jayme.xcodeproj/project.pbxproj
@@ -8,6 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		511019231CF3532600380481 /* Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511019221CF3532600380481 /* Compatibility.swift */; };
+		514A07BC1E4A594F0059C693 /* Creatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514A07BB1E4A594F0059C693 /* Creatable.swift */; };
+		514A07BE1E4A595F0059C693 /* Updatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514A07BD1E4A595F0059C693 /* Updatable.swift */; };
+		514A07C01E4A59680059C693 /* Deletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514A07BF1E4A59680059C693 /* Deletable.swift */; };
+		514A07C21E4A59E80059C693 /* CreatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514A07C11E4A59E80059C693 /* CreatableTests.swift */; };
+		514A07C41E4A59F00059C693 /* ReadableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514A07C31E4A59F00059C693 /* ReadableTests.swift */; };
+		514A07C61E4A59F70059C693 /* UpdatableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514A07C51E4A59F70059C693 /* UpdatableTests.swift */; };
+		514A07C81E4A5A000059C693 /* DeletableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514A07C71E4A5A000059C693 /* DeletableTests.swift */; };
 		5163A0361CD7879900B0EEEF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A02E1CD7879900B0EEEF /* AppDelegate.swift */; };
 		5163A0371CD7879900B0EEEF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5163A02F1CD7879900B0EEEF /* Assets.xcassets */; };
 		5163A0381CD7879900B0EEEF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5163A0301CD7879900B0EEEF /* LaunchScreen.storyboard */; };
@@ -18,7 +25,7 @@
 		5163A0791CD7967900B0EEEF /* JaymeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0781CD7967900B0EEEF /* JaymeError.swift */; };
 		5163A07B1CD7970200B0EEEF /* HTTPResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A07A1CD7970200B0EEEF /* HTTPResponseParser.swift */; };
 		5163A07D1CD797E800B0EEEF /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A07C1CD797E800B0EEEF /* Repository.swift */; };
-		5163A07F1CD79A3B00B0EEEF /* CRUDRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A07E1CD79A3B00B0EEEF /* CRUDRepository.swift */; };
+		5163A07F1CD79A3B00B0EEEF /* Readable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A07E1CD79A3B00B0EEEF /* Readable.swift */; };
 		5163A0811CD79C6300B0EEEF /* PagedRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0801CD79C6300B0EEEF /* PagedRepository.swift */; };
 		5163A0831CD79FAB00B0EEEF /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0821CD79FAB00B0EEEF /* Identifiable.swift */; };
 		5163A0851CD7A01500B0EEEF /* DictionaryInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5163A0841CD7A01500B0EEEF /* DictionaryInitializable.swift */; };
@@ -37,7 +44,6 @@
 		516ECB0D1CD7AB6A0090A176 /* HTTPResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB031CD7AB6A0090A176 /* HTTPResponseParserTests.swift */; };
 		516ECB0E1CD7AB6A0090A176 /* URLSessionBackendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB041CD7AB6A0090A176 /* URLSessionBackendTests.swift */; };
 		516ECB0F1CD7AB6A0090A176 /* PagedRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB051CD7AB6A0090A176 /* PagedRepositoryTests.swift */; };
-		516ECB101CD7AB6A0090A176 /* CRUDRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB061CD7AB6A0090A176 /* CRUDRepositoryTests.swift */; };
 		516ECB111CD7AB6A0090A176 /* TestDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB071CD7AB6A0090A176 /* TestDocument.swift */; };
 		516ECB121CD7AB6A0090A176 /* TestDocumentPagedRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB081CD7AB6A0090A176 /* TestDocumentPagedRepository.swift */; };
 		516ECB131CD7AB6A0090A176 /* TestDocumentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516ECB091CD7AB6A0090A176 /* TestDocumentRepository.swift */; };
@@ -69,6 +75,13 @@
 
 /* Begin PBXFileReference section */
 		511019221CF3532600380481 /* Compatibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Compatibility.swift; sourceTree = "<group>"; };
+		514A07BB1E4A594F0059C693 /* Creatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Creatable.swift; sourceTree = "<group>"; };
+		514A07BD1E4A595F0059C693 /* Updatable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Updatable.swift; sourceTree = "<group>"; };
+		514A07BF1E4A59680059C693 /* Deletable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Deletable.swift; sourceTree = "<group>"; };
+		514A07C11E4A59E80059C693 /* CreatableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CreatableTests.swift; sourceTree = "<group>"; };
+		514A07C31E4A59F00059C693 /* ReadableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReadableTests.swift; sourceTree = "<group>"; };
+		514A07C51E4A59F70059C693 /* UpdatableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdatableTests.swift; sourceTree = "<group>"; };
+		514A07C71E4A5A000059C693 /* DeletableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeletableTests.swift; sourceTree = "<group>"; };
 		5163A0091CD7873800B0EEEF /* Jayme.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Jayme.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5163A01D1CD7873800B0EEEF /* JaymeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JaymeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5163A0231CD7873800B0EEEF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -83,7 +96,7 @@
 		5163A0781CD7967900B0EEEF /* JaymeError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JaymeError.swift; sourceTree = "<group>"; };
 		5163A07A1CD7970200B0EEEF /* HTTPResponseParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPResponseParser.swift; sourceTree = "<group>"; };
 		5163A07C1CD797E800B0EEEF /* Repository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
-		5163A07E1CD79A3B00B0EEEF /* CRUDRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CRUDRepository.swift; sourceTree = "<group>"; };
+		5163A07E1CD79A3B00B0EEEF /* Readable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Readable.swift; sourceTree = "<group>"; };
 		5163A0801CD79C6300B0EEEF /* PagedRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagedRepository.swift; sourceTree = "<group>"; };
 		5163A0821CD79FAB00B0EEEF /* Identifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
 		5163A0841CD7A01500B0EEEF /* DictionaryInitializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryInitializable.swift; sourceTree = "<group>"; };
@@ -102,7 +115,6 @@
 		516ECB031CD7AB6A0090A176 /* HTTPResponseParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPResponseParserTests.swift; sourceTree = "<group>"; };
 		516ECB041CD7AB6A0090A176 /* URLSessionBackendTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionBackendTests.swift; sourceTree = "<group>"; };
 		516ECB051CD7AB6A0090A176 /* PagedRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagedRepositoryTests.swift; sourceTree = "<group>"; };
-		516ECB061CD7AB6A0090A176 /* CRUDRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CRUDRepositoryTests.swift; sourceTree = "<group>"; };
 		516ECB071CD7AB6A0090A176 /* TestDocument.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDocument.swift; sourceTree = "<group>"; };
 		516ECB081CD7AB6A0090A176 /* TestDocumentPagedRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDocumentPagedRepository.swift; sourceTree = "<group>"; };
 		516ECB091CD7AB6A0090A176 /* TestDocumentRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDocumentRepository.swift; sourceTree = "<group>"; };
@@ -235,7 +247,7 @@
 			isa = PBXGroup;
 			children = (
 				5163A07C1CD797E800B0EEEF /* Repository.swift */,
-				51F29C861CFF73660048BCBB /* CRUDRepository */,
+				51F29C861CFF73660048BCBB /* CRUD */,
 				51F29C851CFF73580048BCBB /* PagedRepository */,
 			);
 			name = Repositories;
@@ -296,9 +308,12 @@
 				5198F7341D42623B00917B7E /* Example */,
 				516ECB041CD7AB6A0090A176 /* URLSessionBackendTests.swift */,
 				518CEA3E1CD8DD5900A4CA06 /* PageInfoTests.swift */,
-				516ECB061CD7AB6A0090A176 /* CRUDRepositoryTests.swift */,
 				516ECB051CD7AB6A0090A176 /* PagedRepositoryTests.swift */,
 				516ECB031CD7AB6A0090A176 /* HTTPResponseParserTests.swift */,
+				514A07C11E4A59E80059C693 /* CreatableTests.swift */,
+				514A07C31E4A59F00059C693 /* ReadableTests.swift */,
+				514A07C51E4A59F70059C693 /* UpdatableTests.swift */,
+				514A07C71E4A5A000059C693 /* DeletableTests.swift */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -397,12 +412,15 @@
 			name = PagedRepository;
 			sourceTree = "<group>";
 		};
-		51F29C861CFF73660048BCBB /* CRUDRepository */ = {
+		51F29C861CFF73660048BCBB /* CRUD */ = {
 			isa = PBXGroup;
 			children = (
-				5163A07E1CD79A3B00B0EEEF /* CRUDRepository.swift */,
+				514A07BB1E4A594F0059C693 /* Creatable.swift */,
+				5163A07E1CD79A3B00B0EEEF /* Readable.swift */,
+				514A07BD1E4A595F0059C693 /* Updatable.swift */,
+				514A07BF1E4A59680059C693 /* Deletable.swift */,
 			);
-			name = CRUDRepository;
+			name = CRUD;
 			sourceTree = "<group>";
 		};
 		51F6D1CC1CF89D0500E998F0 /* Identifiers */ = {
@@ -532,6 +550,7 @@
 				518951A51CD923F300089906 /* UserDetailViewController.swift in Sources */,
 				5163A07D1CD797E800B0EEEF /* Repository.swift in Sources */,
 				518951951CD91B2E00089906 /* User.swift in Sources */,
+				514A07BC1E4A594F0059C693 /* Creatable.swift in Sources */,
 				5163A07B1CD7970200B0EEEF /* HTTPResponseParser.swift in Sources */,
 				5163A0911CD7A2AF00B0EEEF /* Logger.swift in Sources */,
 				5163A0361CD7879900B0EEEF /* AppDelegate.swift in Sources */,
@@ -543,11 +562,13 @@
 				5163A0871CD7A0DB00B0EEEF /* DictionaryRepresentable.swift in Sources */,
 				51F6D1CB1CF89B9B00E998F0 /* PostIdentifier.swift in Sources */,
 				5189519A1CD91CA500089906 /* UserTableViewCell.swift in Sources */,
-				5163A07F1CD79A3B00B0EEEF /* CRUDRepository.swift in Sources */,
+				5163A07F1CD79A3B00B0EEEF /* Readable.swift in Sources */,
+				514A07C01E4A59680059C693 /* Deletable.swift in Sources */,
 				518951A91CD9255800089906 /* PostRepository.swift in Sources */,
 				51F6D1C91CF89B2900E998F0 /* Extensions.swift in Sources */,
 				5163A0891CD7A14400B0EEEF /* HTTPHeader.swift in Sources */,
 				5163A0731CD78B5E00B0EEEF /* Backend.swift in Sources */,
+				514A07BE1E4A595F0059C693 /* Updatable.swift in Sources */,
 				518951921CD91A6B00089906 /* UsersViewController.swift in Sources */,
 				511019231CF3532600380481 /* Compatibility.swift in Sources */,
 			);
@@ -558,15 +579,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				518CEA3F1CD8DD5900A4CA06 /* PageInfoTests.swift in Sources */,
-				516ECB101CD7AB6A0090A176 /* CRUDRepositoryTests.swift in Sources */,
 				516ECB0A1CD7AB6A0090A176 /* FakeHTTPResponseParser.swift in Sources */,
 				516ECB0E1CD7AB6A0090A176 /* URLSessionBackendTests.swift in Sources */,
+				514A07C81E4A5A000059C693 /* DeletableTests.swift in Sources */,
 				516ECB0D1CD7AB6A0090A176 /* HTTPResponseParserTests.swift in Sources */,
 				516ECB131CD7AB6A0090A176 /* TestDocumentRepository.swift in Sources */,
 				516ECB0C1CD7AB6A0090A176 /* FakeURLSession.swift in Sources */,
+				514A07C41E4A59F00059C693 /* ReadableTests.swift in Sources */,
+				514A07C61E4A59F70059C693 /* UpdatableTests.swift in Sources */,
 				516ECB111CD7AB6A0090A176 /* TestDocument.swift in Sources */,
 				516ECB0B1CD7AB6A0090A176 /* TestingBackend.swift in Sources */,
 				516ECB121CD7AB6A0090A176 /* TestDocumentPagedRepository.swift in Sources */,
+				514A07C21E4A59E80059C693 /* CreatableTests.swift in Sources */,
 				51AE549E1D4275E900797FC8 /* UserRepositoryTests.swift in Sources */,
 				516ECB0F1CD7AB6A0090A176 /* PagedRepositoryTests.swift in Sources */,
 			);

--- a/Jayme/Compatibility.swift
+++ b/Jayme/Compatibility.swift
@@ -42,6 +42,16 @@ public typealias NSURLSessionBackendConfiguration = URLSessionBackendConfigurati
 @available(*, unavailable, renamed : "JaymeError")
 public typealias ServerBackendError = JaymeError
 
+/// ServerRepository -> CRUDRepository
+@available(*, unavailable, renamed : "CRUDRepository")
+public typealias ServerRepository = CRUDRepository
+
+/// CRUDRepository -> Creatable, Readable, Updatable, Deletable
+@available(*, deprecated: 2.0, message: "Use Creatable, Readable, Updatable and Deletable protocols instead")
+public protocol CRUDRepository: Creatable, Readable, Updatable, Deletable {
+    
+}
+
 /// ServerPagedRepository -> PagedRepository
 @available(*, unavailable, renamed : "PagedRepository")
 public typealias ServerPagedRepository = PagedRepository

--- a/Jayme/Compatibility.swift
+++ b/Jayme/Compatibility.swift
@@ -42,10 +42,6 @@ public typealias NSURLSessionBackendConfiguration = URLSessionBackendConfigurati
 @available(*, unavailable, renamed : "JaymeError")
 public typealias ServerBackendError = JaymeError
 
-/// ServerRepository -> CRUDRepository
-@available(*, unavailable, renamed : "CRUDRepository")
-public typealias ServerRepository = CRUDRepository
-
 /// ServerPagedRepository -> PagedRepository
 @available(*, unavailable, renamed : "PagedRepository")
 public typealias ServerPagedRepository = PagedRepository

--- a/Jayme/Creatable.swift
+++ b/Jayme/Creatable.swift
@@ -1,5 +1,5 @@
-// JaymeExample
-// PostRepository.swift
+// Jayme
+// Creatable.swift
 //
 // Copyright (c) 2016 Inaka - http://inaka.net/
 //
@@ -20,16 +20,19 @@
 
 import Foundation
 
-class PostRepository: Readable {
+public protocol Creatable: Repository {
+    associatedtype EntityType: DictionaryInitializable, DictionaryRepresentable
+    var backend: URLSessionBackend { get }
+}
+
+public extension Creatable {
     
-    typealias EntityType = Post
-    let backend = URLSessionBackend()
-    let name = "posts"
-    
-    func findPosts(for user: User) -> Future<[Post], JaymeError> {
-        return self.findAll().map {
-            $0.filter { $0.authorId == user.id }
-        }
+    /// Creates the entity in the repository. Returns a `Future` with the created entity or a `JaymeError`.
+    public func create(_ entity: EntityType) -> Future<EntityType, JaymeError> {
+        let path = self.name
+        return self.backend.future(path: path, method: .POST, parameters: entity.dictionaryValue)
+            .andThen { DataParser().dictionary(from: $0.0) }
+            .andThen { EntityParser().entity(from: $0) }
     }
     
 }

--- a/Jayme/Creatable.swift
+++ b/Jayme/Creatable.swift
@@ -20,6 +20,7 @@
 
 import Foundation
 
+/// A repository that is capable of creating entities
 public protocol Creatable: Repository {
     associatedtype EntityType: DictionaryInitializable, DictionaryRepresentable
     var backend: URLSessionBackend { get }

--- a/Jayme/Deletable.swift
+++ b/Jayme/Deletable.swift
@@ -1,5 +1,5 @@
-// JaymeExample
-// PostRepository.swift
+// Jayme
+// Deletable.swift
 //
 // Copyright (c) 2016 Inaka - http://inaka.net/
 //
@@ -20,16 +20,18 @@
 
 import Foundation
 
-class PostRepository: Readable {
+public protocol Deletable: Repository {
+    associatedtype EntityType: Identifiable
+    var backend: URLSessionBackend { get }
+}
+
+public extension Deletable {
     
-    typealias EntityType = Post
-    let backend = URLSessionBackend()
-    let name = "posts"
-    
-    func findPosts(for user: User) -> Future<[Post], JaymeError> {
-        return self.findAll().map {
-            $0.filter { $0.authorId == user.id }
-        }
+    /// Deletes the entity from the repository. Returns a `Future` with a `Void` result or a `JaymeError`.
+    public func delete(_ entity: EntityType) -> Future<Void, JaymeError> {
+        let path = "\(self.name)/\(entity.id)"
+        return self.backend.future(path: path, method: .DELETE, parameters: nil)
+            .map { _ in return }
     }
     
 }

--- a/Jayme/Deletable.swift
+++ b/Jayme/Deletable.swift
@@ -20,6 +20,7 @@
 
 import Foundation
 
+/// A repository that is capable of deleting entities
 public protocol Deletable: Repository {
     associatedtype EntityType: Identifiable
     var backend: URLSessionBackend { get }

--- a/Jayme/PagedRepository.swift
+++ b/Jayme/PagedRepository.swift
@@ -22,6 +22,7 @@ import Foundation
 
 /// Provides a `Repository` serving read functionality with pagination, based on Grape conventions (https://github.com/davidcelis/api-pagination)
 public protocol PagedRepository: Repository {
+    associatedtype EntityType: DictionaryInitializable
     /// Indicates the number of entities to be fetched per page.
     var pageSize: Int { get }
     var backend: URLSessionBackend { get }

--- a/Jayme/Readable.swift
+++ b/Jayme/Readable.swift
@@ -1,5 +1,5 @@
 // Jayme
-// CRUDRepository.swift
+// Readable.swift
 //
 // Copyright (c) 2016 Inaka - http://inaka.net/
 //
@@ -20,14 +20,12 @@
 
 import Foundation
 
-/// Provides a `Repository` with convenient implementations ready to be used in any repository that needs basic CRUD functionality.
-public protocol CRUDRepository: Repository {
+public protocol Readable: Repository {
+    associatedtype EntityType: Identifiable, DictionaryInitializable
     var backend: URLSessionBackend { get }
 }
 
-// MARK: - Basic Methods API
-
-public extension CRUDRepository {
+public extension Readable {
     
     /// Returns a `Future` containing an array of all the entities in the repository, or the relevant `JaymeError` that could occur.
     public func findAll() -> Future<[EntityType], JaymeError> {
@@ -40,39 +38,10 @@ public extension CRUDRepository {
     /// Returns a `Future` containing the entity matching the `id`, or the relevant `JaymeError` that could occur.
     /// Watch out for a `.failure` case with `JaymeError.entityNotFound`.
     public func find(byId id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
-        let path = self.path(for: id)
+        let path = "\(self.name)/\(id)"
         return self.backend.future(path: path, method: .GET, parameters: nil)
             .andThen { DataParser().dictionary(from: $0.0) }
             .andThen { EntityParser().entity(from: $0) }
-    }
-    
-    /// Creates the entity in the repository. Returns a `Future` with the created entity or a `JaymeError`.
-    public func create(_ entity: EntityType) -> Future<EntityType, JaymeError> {
-        let path = self.name
-        return self.backend.future(path: path, method: .POST, parameters: entity.dictionaryValue)
-            .andThen { DataParser().dictionary(from: $0.0) }
-            .andThen { EntityParser().entity(from: $0) }
-    }
-    
-    /// Updates the entity in the repository. Returns a `Future` with the updated entity or a `JaymeError`.
-    public func update(_ entity: EntityType) -> Future<EntityType, JaymeError> {
-        let path = self.path(for: entity.id)
-        return self.backend.future(path: path, method: .PUT, parameters: entity.dictionaryValue)
-            .andThen { DataParser().dictionary(from: $0.0) }
-            .andThen { EntityParser().entity(from: $0) }
-    }
-    
-    /// Deletes the entity from the repository. Returns a `Future` with a `Void` result or a `JaymeError`.
-    public func delete(_ entity: EntityType) -> Future<Void, JaymeError> {
-        let path = self.path(for: entity.id)
-        return self.backend.future(path: path, method: .DELETE, parameters: nil)
-            .map { _ in return }
-    }
-    
-    // MARK: - Private
-    
-    fileprivate func path(for id: EntityType.IdentifierType) -> Path {
-        return "\(self.name)/\(id)"
     }
     
 }

--- a/Jayme/Readable.swift
+++ b/Jayme/Readable.swift
@@ -20,6 +20,7 @@
 
 import Foundation
 
+/// A repository that is capable of reading entities
 public protocol Readable: Repository {
     associatedtype EntityType: Identifiable, DictionaryInitializable
     var backend: URLSessionBackend { get }

--- a/Jayme/Repository.swift
+++ b/Jayme/Repository.swift
@@ -20,13 +20,8 @@
 
 import Foundation
 
-
 /// Abstraction that represents a repository of a certain kind of entities.
 public protocol Repository {
-        
-    /// The entity type that the repository works with (e.g. `User`).
-    /// Classes conforming to `Repository` must tie this associated type to a concrete type.
-    associatedtype EntityType: Identifiable, DictionaryInitializable, DictionaryRepresentable
     
     /// The backend type going to be used in the repository.
     associatedtype BackendType: Backend

--- a/Jayme/Updatable.swift
+++ b/Jayme/Updatable.swift
@@ -20,6 +20,7 @@
 
 import Foundation
 
+/// A repository that is capable of updating entities
 public protocol Updatable: Repository {
     associatedtype EntityType: Identifiable, DictionaryInitializable, DictionaryRepresentable
     var backend: URLSessionBackend { get }

--- a/JaymeTests/CreatableTests.swift
+++ b/JaymeTests/CreatableTests.swift
@@ -1,0 +1,112 @@
+// Jayme
+// CreatableTests.swift
+//
+// Copyright (c) 2016 Inaka - http://inaka.net/
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import XCTest
+@testable import Jayme
+
+class CreatableTests: XCTestCase {
+    
+    var backend: TestingBackend!
+    var repository: TestDocumentRepository!
+    
+    override func setUp() {
+        super.setUp()
+        self.continueAfterFailure = false
+        
+        let backend = TestingBackend()
+        self.backend = backend
+        self.repository = TestDocumentRepository(backend: self.backend)
+    }
+    
+}
+
+extension CreatableTests {
+    
+    // MARK: - Call To backend
+    
+    func testCreateCall() {
+        let document = TestDocument(id: "123", name: "a")
+        let _ = self.repository.create(document)
+        XCTAssertEqual(self.backend.path, "documents")
+        XCTAssertEqual(self.backend.method, .POST)
+        guard
+            let id = self.backend.parameters?["id"] as? String,
+            let name = self.backend.parameters?["name"] as? String
+            else {
+                XCTFail("Wrong parameters"); return
+        }
+        XCTAssertEqual(id, "123")
+        XCTAssertEqual(name, "a")
+    }
+    
+    // MARK: - Success Response
+    
+    func testCreateSuccessCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let json = ["id": "1", "name": "a"]
+            let data = try! JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+            completion(.success((data, nil)))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get a success")
+        
+        let document = TestDocument(id: "_", name: "_")
+        let future = self.repository.create(document)
+        future.start() { result in
+            guard case .success(let document) = result
+                else { XCTFail(); return }
+            XCTAssertEqual(document.id, "1")
+            XCTAssertEqual(document.name, "a")
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+
+    // MARK: - Failure Response
+    
+    func testCreateFailureCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let error = JaymeError.notFound
+            completion(.failure(error))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get an error")
+        
+        let document = TestDocument(id: "_", name: "_")
+        let future = self.repository.create(document)
+        future.start() { result in
+            guard case .failure = result
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+
+}

--- a/JaymeTests/DeletableTests.swift
+++ b/JaymeTests/DeletableTests.swift
@@ -1,0 +1,100 @@
+// Jayme
+// DeletableTests.swift
+//
+// Copyright (c) 2016 Inaka - http://inaka.net/
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import XCTest
+@testable import Jayme
+
+class DeletableTests: XCTestCase {
+    
+    var backend: TestingBackend!
+    var repository: TestDocumentRepository!
+    
+    override func setUp() {
+        super.setUp()
+        self.continueAfterFailure = false
+        
+        let backend = TestingBackend()
+        self.backend = backend
+        self.repository = TestDocumentRepository(backend: self.backend)
+    }
+    
+}
+
+extension DeletableTests {
+    
+    // MARK: - Call To backend
+    
+    func testDeleteCall() {
+        let document = TestDocument(id: "123", name: "a")
+        let _ = self.repository.delete(document)
+        XCTAssertEqual(self.backend.path, "documents/123")
+        XCTAssertEqual(self.backend.method, .DELETE)
+    }
+    
+    // MARK: - Success Response
+    
+    func testDeleteSuccessCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            completion(.success((nil, nil)))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get a success")
+        
+        let document = TestDocument(id: "_", name: "_")
+        let future = self.repository.delete(document)
+        future.start() { result in
+            guard case .success = result
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+    
+    // MARK: - Failure Response
+    
+    func testDeleteFailureCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let error = JaymeError.notFound
+            completion(.failure(error))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get an error")
+        
+        let document = TestDocument(id: "_", name: "_")
+        let future = self.repository.delete(document)
+        future.start() { result in
+            guard case .failure = result
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+    
+}

--- a/JaymeTests/ReadableTests.swift
+++ b/JaymeTests/ReadableTests.swift
@@ -1,5 +1,5 @@
 // Jayme
-// CRUDRepositoryTests.swift
+// ReadableTests.swift
 //
 // Copyright (c) 2016 Inaka - http://inaka.net/
 //
@@ -18,12 +18,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// swiftlint:disable file_length
-
 import XCTest
 @testable import Jayme
 
-class CRUDRepositoryTests: XCTestCase {
+class ReadableTests: XCTestCase {
     
     var backend: TestingBackend!
     var repository: TestDocumentRepository!
@@ -34,14 +32,16 @@ class CRUDRepositoryTests: XCTestCase {
         
         let backend = TestingBackend()
         self.backend = backend
-        self.repository = TestDocumentRepository(backend: backend)
+        self.repository = TestDocumentRepository(backend: self.backend)
     }
     
 }
 
-// MARK: - Calls To Backend Tests
+// MARK: - Find All
 
-extension CRUDRepositoryTests {
+extension ReadableTests {
+    
+    // MARK: - Call To Backend
     
     func testFindAllCall() {
         let _ = self.repository.findAll()
@@ -49,53 +49,7 @@ extension CRUDRepositoryTests {
         XCTAssertEqual(self.backend.method, .GET)
     }
     
-    func testFindByIdCall() {
-        let _ = self.repository.find(byId: "123")
-        XCTAssertEqual(self.backend.path, "documents/123")
-        XCTAssertEqual(self.backend.method, .GET)
-    }
-    
-    func testCreateCall() {
-        let document = TestDocument(id: "123", name: "a")
-        let _ = self.repository.create(document)
-        XCTAssertEqual(self.backend.path, "documents")
-        XCTAssertEqual(self.backend.method, .POST)
-        guard
-            let id = self.backend.parameters?["id"] as? String,
-            let name = self.backend.parameters?["name"] as? String
-            else {
-                XCTFail("Wrong parameters"); return
-        }
-        XCTAssertEqual(id, "123")
-        XCTAssertEqual(name, "a")
-    }
-    
-    func testUpdateCall() {
-        let document = TestDocument(id: "123", name: "b")
-        let _ = self.repository.update(document)
-        XCTAssertEqual(self.backend.path, "documents/123")
-        XCTAssertEqual(self.backend.method, .PUT)
-        guard let
-            id = self.backend.parameters?["id"] as? String,
-            let name = self.backend.parameters?["name"] as? String else {
-                XCTFail("Wrong parameters"); return
-        }
-        XCTAssertEqual(id, "123")
-        XCTAssertEqual(name, "b")
-    }
-    
-    func testDeleteCall() {
-        let document = TestDocument(id: "123", name: "a")
-        let _ = self.repository.delete(document)
-        XCTAssertEqual(self.backend.path, "documents/123")
-        XCTAssertEqual(self.backend.method, .DELETE)
-    }
-    
-}
-
-// MARK: - Response Callbacks Tests
-
-extension CRUDRepositoryTests {
+    // MARK: - Success Response
     
     func testFindAllSuccessCallback() {
         
@@ -125,6 +79,8 @@ extension CRUDRepositoryTests {
             if let _ = error { XCTFail() }
         }
     }
+    
+    // MARK: - Failure Response
     
     func testFindAllFailureNotFoundCallback() {
         
@@ -170,6 +126,21 @@ extension CRUDRepositoryTests {
             if let _ = error { XCTFail() }
         }
     }
+}
+
+// MARK: - Find By ID
+
+extension ReadableTests {
+    
+    // MARK: - Call To Backend
+    
+    func testFindByIdCall() {
+        let _ = self.repository.find(byId: "123")
+        XCTAssertEqual(self.backend.path, "documents/123")
+        XCTAssertEqual(self.backend.method, .GET)
+    }
+    
+    // MARK: - Success Response
     
     func testFindByIdSuccessCallback() {
         
@@ -195,6 +166,8 @@ extension CRUDRepositoryTests {
             if let _ = error { XCTFail() }
         }
     }
+    
+    // MARK: - Failure Response
     
     func testFindByIdFailureNotFoundCallback() {
         
@@ -268,149 +241,5 @@ extension CRUDRepositoryTests {
             if let _ = error { XCTFail() }
         }
     }
-    
-    func testCreateSuccessCallback() {
-        
-        // Simulated completion
-        self.backend.completion = { completion in
-            let json = ["id": "1", "name": "a"]
-            let data = try! JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
-            completion(.success((data, nil)))
-        }
-        
-        let expectation = self.expectation(description: "Expected to get a success")
-        
-        let document = TestDocument(id: "_", name: "_")
-        let future = self.repository.create(document)
-        future.start() { result in
-            guard case .success(let document) = result
-                else { XCTFail(); return }
-            XCTAssertEqual(document.id, "1")
-            XCTAssertEqual(document.name, "a")
-            expectation.fulfill()
-        }
-        
-        self.waitForExpectations(timeout: 3) { error in
-            if let _ = error { XCTFail() }
-        }
-    }
-    
-    func testCreateFailureCallback() {
-        
-        // Simulated completion
-        self.backend.completion = { completion in
-            let error = JaymeError.notFound
-            completion(.failure(error))
-        }
-        
-        let expectation = self.expectation(description: "Expected to get an error")
-        
-        let document = TestDocument(id: "_", name: "_")
-        let future = self.repository.create(document)
-        future.start() { result in
-            guard case .failure = result
-                else { XCTFail(); return }
-            expectation.fulfill()
-        }
-        
-        self.waitForExpectations(timeout: 3) { error in
-            if let _ = error { XCTFail() }
-        }
-    }
-    
-    
-    func testUpdateSuccessCallback() {
-        
-        // Simulated completion
-        self.backend.completion = { completion in
-            let json = ["id": "1", "name": "a"]
-            let data = try! JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
-            completion(.success((data, nil)))
-        }
-        
-        let expectation = self.expectation(description: "Expected to get a success")
-        
-        let document = TestDocument(id: "_", name: "_")
-        let future = self.repository.update(document)
-        future.start() { result in
-            guard case .success(let document) = result
-                else { XCTFail(); return }
-            XCTAssertEqual(document.id, "1")
-            XCTAssertEqual(document.name, "a")
-            expectation.fulfill()
-        }
-        
-        self.waitForExpectations(timeout: 3) { error in
-            if let _ = error { XCTFail() }
-        }
-    }
-    
-    func testUpdateFailureCallback() {
-        
-        // Simulated completion
-        self.backend.completion = { completion in
-            let error = JaymeError.notFound
-            completion(.failure(error))
-        }
-        
-        let expectation = self.expectation(description: "Expected to get an error")
-        
-        let document = TestDocument(id: "_", name: "_")
-        let future = self.repository.update(document)
-        future.start() { result in
-            guard case .failure = result
-                else { XCTFail(); return }
-            expectation.fulfill()
-        }
-        
-        self.waitForExpectations(timeout: 3) { error in
-            if let _ = error { XCTFail() }
-        }
-    }
-    
-    func testDeleteSuccessCallback() {
-        
-        // Simulated completion
-        self.backend.completion = { completion in
-            completion(.success((nil, nil)))
-        }
-        
-        let expectation = self.expectation(description: "Expected to get a success")
-        
-        let document = TestDocument(id: "_", name: "_")
-        let future = self.repository.delete(document)
-        future.start() { result in
-            guard case .success = result
-                else { XCTFail(); return }
-            expectation.fulfill()
-        }
-        
-        self.waitForExpectations(timeout: 3) { error in
-            if let _ = error { XCTFail() }
-        }
-    }
-    
-    func testDeleteFailureCallback() {
-        
-        // Simulated completion
-        self.backend.completion = { completion in
-            let error = JaymeError.notFound
-            completion(.failure(error))
-        }
-        
-        let expectation = self.expectation(description: "Expected to get an error")
-        
-        let document = TestDocument(id: "_", name: "_")
-        let future = self.repository.delete(document)
-        future.start() { result in
-            guard case .failure = result
-                else { XCTFail(); return }
-            expectation.fulfill()
-        }
-        
-        self.waitForExpectations(timeout: 3) { error in
-            if let _ = error { XCTFail() }
-        }
-    }
-    
 }
+

--- a/JaymeTests/ReadableTests.swift
+++ b/JaymeTests/ReadableTests.swift
@@ -242,4 +242,3 @@ extension ReadableTests {
         }
     }
 }
-

--- a/JaymeTests/TestDocumentRepository.swift
+++ b/JaymeTests/TestDocumentRepository.swift
@@ -21,7 +21,8 @@
 import Foundation
 @testable import Jayme
 
-class TestDocumentRepository: CRUDRepository {
+class TestDocumentRepository: Creatable, Readable, Updatable, Deletable {
+    
     typealias EntityType = TestDocument
     let name = "documents"
     let backend: URLSessionBackend
@@ -29,4 +30,5 @@ class TestDocumentRepository: CRUDRepository {
     init(backend: URLSessionBackend) {
         self.backend = backend
     }
+    
 }

--- a/JaymeTests/UpdatableTests.swift
+++ b/JaymeTests/UpdatableTests.swift
@@ -1,0 +1,112 @@
+// Jayme
+// UpdatableTests.swift
+//
+// Copyright (c) 2016 Inaka - http://inaka.net/
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import XCTest
+@testable import Jayme
+
+class UpdatableTests: XCTestCase {
+    
+    var backend: TestingBackend!
+    var repository: TestDocumentRepository!
+    
+    override func setUp() {
+        super.setUp()
+        self.continueAfterFailure = false
+        
+        let backend = TestingBackend()
+        self.backend = backend
+        self.repository = TestDocumentRepository(backend: self.backend)
+    }
+    
+}
+
+extension UpdatableTests {
+    
+    // MARK: - Call To backend
+    
+    func testUpdateCall() {
+        let document = TestDocument(id: "123", name: "b")
+        let _ = self.repository.update(document)
+        XCTAssertEqual(self.backend.path, "documents/123")
+        XCTAssertEqual(self.backend.method, .PUT)
+        guard let
+            id = self.backend.parameters?["id"] as? String,
+            let name = self.backend.parameters?["name"] as? String else {
+                XCTFail("Wrong parameters"); return
+        }
+        XCTAssertEqual(id, "123")
+        XCTAssertEqual(name, "b")
+    }
+    
+    // MARK: - Success Response
+    
+    func testUpdateSuccessCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let json = ["id": "1", "name": "a"]
+            let data = try! JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+            completion(.success((data, nil)))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get a success")
+        
+        let document = TestDocument(id: "_", name: "_")
+        let future = self.repository.update(document)
+        future.start() { result in
+            guard case .success(let document) = result
+                else { XCTFail(); return }
+            XCTAssertEqual(document.id, "1")
+            XCTAssertEqual(document.name, "a")
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+        
+    }
+    
+    // MARK: - Failure Response
+    
+    func testUpdateFailureCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let error = JaymeError.notFound
+            completion(.failure(error))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get an error")
+        
+        let document = TestDocument(id: "_", name: "_")
+        let future = self.repository.update(document)
+        future.start() { result in
+            guard case .failure = result
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+    
+}


### PR DESCRIPTION
Related issue: #84

`CRUDRepository` is deprecated. Its functionalities are now available via `Creatable`, `Readable`, `Updatable` and `Deletable` protocols.