### PR TITLE
CRUD Extra Operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to this project will be documented in this file. `Jayme` a
 
 - `CRUDRepository` protocol no longer exists. Its functionalities have now been divided into four separate protocols: `Creatable`, `Readable`, `Updatable` and `Deletable`. (Issue [#84](https://github.com/inaka/Jayme/issues/84))
 - `findAll()` has been renamed to `readAll()` in the `Readable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
-- `find(byId:)` has been renamed to `read(id:)` in the `Readable`protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
+- `find(byId:)` has been renamed to `read(id:)` in the `Readable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
 - `update(_)` has been renamed to `update(_, id:)` in the `Updatable` protocol; a new `update(_)` function has been added (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
 - `delete(_)` has been renamed to `delete(id:)` in the `Deletable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
 - Added `create([entity1, entity2, …])` function in the `Creatable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file. `Jayme` a
 
 ---
 
+### 4.x Releases
+
+- `4.0.x` releases - [4.0.0](#400)
+
 ### 3.x Releases
 
-- `3.0.x` releases - [3.0.0](#300) - [3.1.0](#310)
+- `3.0.x` releases - [3.0.0](#300)
 
 ### 2.x Releases
 
@@ -18,9 +22,17 @@ All notable changes to this project will be documented in this file. `Jayme` a
 
 ---
 
-## 3.1.0
+## 4.0.0
 
 - `CRUDRepository` protocol no longer exists. Its functionalities have now been divided into four separate protocols: `Creatable`, `Readable`, `Updatable` and `Deletable`. (Issue [#84](https://github.com/inaka/Jayme/issues/84))
+- `findAll()` has been renamed to `readAll()` in the `Readable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
+- `find(byId:)` has been renamed to `read(id:)` in the `Readable`protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
+- `update(_)` has been renamed to `update(_, id:)` in the `Updatable` protocol; a new `update(_)` function has been added (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
+- `delete(_)` has been renamed to `delete(id:)` in the `Deletable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
+- Added `create([entity1, entity2, …])` function in the `Creatable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
+- Added `read()` function in the `Readable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87])) 
+- Added `update([entity1, entity2, …])` function in the `Updatable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
+- Added `delete()` function in the `Deletable` protocol (Issue [#87](https://github.com/inaka/Jayme/issues/87]))
 
 ## 3.0.0
 

--- a/Documentation/Jayme 3.0 Migration Guide.md
+++ b/Documentation/Jayme 3.0 Migration Guide.md
@@ -12,7 +12,7 @@ This guide is provided in order to ease the transition of existing applications 
 
 ### Automatically Suggested Changes
 
-There are some compiler migration mechanisms that have been implemented in Jayme 2.0 by leveraging the `@unavailable` attribute in a `Compatibility.swift` file.
+There are some compiler migration mechanisms that have been implemented in Jayme 3.0 by leveraging the `@unavailable` attribute in a `Compatibility.swift` file.
 
 ***For these changes you only have to follow the compiler suggestions and they should be applied automatically.***
 

--- a/Documentation/Jayme 4.0 Migration Guide.md
+++ b/Documentation/Jayme 4.0 Migration Guide.md
@@ -61,6 +61,7 @@ However, there are some other changes that would have required overwhelming (if 
 
 - **CRUDRepository** no longer exists. The compiler will suggest you to use the `Creatable`, `Readable`, `Updatable` and `Deletable` protocols instead, but it's up to you to write which ones each of your repository needs to conform to.
 - **Watch out the `update(_)` method**. In Jayme 3.x, this method appends the entity's `id` to the URL path. In Jayme 4.x, this method does not append the `id`, there is the `update(_, id:)` method for doing so. Therefore, anywhere you were calling `update(entity)`, you have to change it by `update(entity, id: entity.id)`. You have to do it manually, because `update(entity)` still compiles, but has a different behavior as of Jayme 4.0.
+- **Dictionaries** are now represented as `[AnyHashable: Any]` instead of `[String: Any]`. You have to manually change these appearances in your `DictionaryInitializable` and `DictionaryRepresentable` methods of your entities.
 
 ---
 

--- a/Documentation/Jayme 4.0 Migration Guide.md
+++ b/Documentation/Jayme 4.0 Migration Guide.md
@@ -12,7 +12,7 @@ Based in our experiences by using Jayme in production projects, **we've decided 
 
 #### Better organized CRUD API
 
-The main change that you need to be aware of is that **your repositories will no longer conform to a `CRUDRepository` protocol**. Instead, they can conform to `Creatable`, `Readable`, `Updatable` and `Designable` protocols, depending on what each repository needs.
+The main change that you need to be aware of is that **your repositories will no longer conform to a `CRUDRepository` protocol**. Instead, they can conform to `Creatable`, `Readable`, `Updatable` and `Deletable` protocols, depending on what each repository needs.
 
 By organizing the CRUD API this way, your code will follow the [YAGNI principle](https://en.wikipedia.org/wiki/You_aren't_gonna_need_it) better than before. For instance: If you have a repository whose entities only need to be _read_, but not _created_, _updated_ or _deleted_, then you shouldn't need to write a `dictionaryValue` method for that entity type at all. You were forced to do so when conforming to `CRUDRepository`, but now, by only conforming to the `Readable` protocol, you don't have to.
 

--- a/Documentation/Jayme 4.0 Migration Guide.md
+++ b/Documentation/Jayme 4.0 Migration Guide.md
@@ -1,0 +1,67 @@
+# Jayme 4.0 Migration Guide
+
+**Jayme 4.0** is the latest major release of Jayme. As a major release, following Semantic Versioning conventions, 4.0 introduces several API-breaking changes that one should be aware of.
+
+This guide is provided in order to ease the transition of existing applications using Jayme 4.x to the latest APIs, as well as explain the design and structure of new and changed functionality.
+
+---
+
+Based in our experiences by using Jayme in production projects, **we've decided to focus Jayme 4.0 on an enhanced CRUD API design**, that is better organized as of this version, and provides more functionality.
+
+
+
+#### Better organized CRUD API
+
+The main change that you need to be aware of is that **your repositories will no longer conform to a `CRUDRepository` protocol**. Instead, they can conform to `Creatable`, `Readable`, `Updatable` and `Designable` protocols, depending on what each repository needs.
+
+By organizing the CRUD API this way, your code will follow the [YAGNI principle](https://en.wikipedia.org/wiki/You_aren't_gonna_need_it) better than before. For instance: If you have a repository whose entities only need to be _read_, but not _created_, _updated_ or _deleted_, then you shouldn't need to write a `dictionaryValue` method for that entity type at all. You were forced to do so when conforming to `CRUDRepository`, but now, by only conforming to the `Readable` protocol, you don't have to.
+
+> This new organization has been discussed in the issue [#84](https://github.com/inaka/Jayme/issues/84). Check it out for further reference.
+
+
+
+#### More CRUD functionality
+
+The other breakthrough is that now repositories can be aimed to perform operations in two ways: **single-entity** or **multiple-entity**.
+
+Typical examples of *single-entity* endpoints are `/me`, `/profile` or `/device`, whereas typical examples of *multiple-entity* endpoints are `/users`, `/posts`, `/feed_items` or `/comments`.
+
+Sometimes your repository needs to perform operations that always apply to a single entity. Under this scenario, your repository would not, for instance, delete an entity by `id`, instead, you would prefer to use a generic `delete()` method to delete _the only entity_ that lives in the repository, and not the `delete(id:)` method.
+
+Below is a table exposing all the methods that are available in the `Creatable`, `Readable`, `Updatable` and `Deletable` protocols, categorizing them by interest: *single* vs. *multiple* entity repository.
+
+<table>
+<th></th><th>Single-Entity Repository<br>(e.g. /profile)</th><th>Multiple-Entity Repository<br>(e.g. /users)</th>
+<tr><td><i>Creatable</i></td><td><b>.create(e)</b><br>POST /profile → ⚪ </td><td><b>.create(e)</b><br>POST /users → ⚪<br><br><b>.create([e1, e2, ...])</b><br>POST /users → [⚪ ,⚪ , ...]</td></tr>
+<tr><td><i>Readable</i></td><td><b>.read()</b><br>GET /profile → ⚪ </td><td><b>.read(id: x)</b><br>GET /users/x →⚪ <br><br><b>.readAll()</b><br>GET /users → [⚪ ,⚪ , ...]</td></tr></tr>
+<tr><td><i>Updatable</i></td><td><b>.update(e)</b><br>PUT /profile → ⚪</td><td><b>.update(e, id: x)</b><br>PUT /users/x → ⚪<br><br><b>.update([e1, e2, ...])</b><br>PATCH /users → [⚪ ,⚪ , ...]</td></tr>
+<tr><td><i>Deletable</i></td><td><b>.delete()</b><br>DELETE /profile</td><td><b>.delete(id: x)</b><br>DELETE /users/x</td></tr>
+
+</table>
+
+> This new organization has been discussed in the issue [#87](https://github.com/inaka/Jayme/issues/87). Check it out for further reference.
+
+---
+
+### Automatically Suggested Changes
+
+There are some compiler migration mechanisms that have been implemented in Jayme 4.0 via a `Compatibility.swift` file.
+
+***For these changes you only have to follow the compiler suggestions and they should be applied automatically.***
+
+For instance, `findAll()` has been renamed to `readAll()`: The compiler will automatically suggest the replacement of `findAll()` to `readAll()`.
+
+---
+
+### Manual Changes
+
+However, there are some other changes that would have required overwhelming (if ever possible) mechanisms to be implemented in order to keep automatic suggestions from the compiler. In consequence, we decided not to implement them.
+
+⚠️ ***Therefore, it's up to you to perform these changes manually.***
+
+- **CRUDRepository** no longer exists. The compiler will suggest you to use the `Creatable`, `Readable`, `Updatable` and `Deletable` protocols instead, but it's up to you to write which ones each of your repository needs to conform to.
+- **Watch out the `update(_)` method**. In Jayme 3.x, this method appends the entity's `id` to the URL path. In Jayme 4.x, this method does not append the `id`, there is the `update(_, id:)` method for doing so. Therefore, anywhere you were calling `update(entity)`, you have to change it by `update(entity, id: entity.id)`. You have to do it manually, because `update(entity)` still compiles, but has a different behavior as of Jayme 4.0.
+
+---
+
+For further documentation regarding changes, check out the **[Change Log](../Changelog.md)**.

--- a/Documentation/Jayme 4.0 Migration Guide.md
+++ b/Documentation/Jayme 4.0 Migration Guide.md
@@ -2,7 +2,7 @@
 
 **Jayme 4.0** is the latest major release of Jayme. As a major release, following Semantic Versioning conventions, 4.0 introduces several API-breaking changes that one should be aware of.
 
-This guide is provided in order to ease the transition of existing applications using Jayme 4.x to the latest APIs, as well as explain the design and structure of new and changed functionality.
+This guide is provided in order to ease the transition of existing applications using Jayme 3.x to the latest APIs, as well as explain the design and structure of new and changed functionality.
 
 ---
 

--- a/Example/PostRepository.swift
+++ b/Example/PostRepository.swift
@@ -27,7 +27,7 @@ class PostRepository: Readable {
     let name = "posts"
     
     func findPosts(for user: User) -> Future<[Post], JaymeError> {
-        return self.findAll().map {
+        return self.readAll().map {
             $0.filter { $0.authorId == user.id }
         }
     }

--- a/Example/UsersViewController.swift
+++ b/Example/UsersViewController.swift
@@ -39,7 +39,7 @@ class UsersViewController: UIViewController {
     fileprivate var selectedUser: User?
     
     fileprivate func loadUsers() {
-        UserRepository().findAll().start { result in
+        UserRepository().readAll().start { result in
             switch result {
             case .success(let users):
                 self.users = users

--- a/Example/UsersViewController.swift
+++ b/Example/UsersViewController.swift
@@ -26,6 +26,7 @@ class UsersViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        guard NSClassFromString("XCTestCase") == nil else { return }
         self.loadUsers()
     }
     

--- a/Jayme.podspec
+++ b/Jayme.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Jayme"
-  s.version      = "3.1.0"
+  s.version      = "4.0.0"
   s.summary      = "An abstraction layer that eases RESTful interconnections in Swift"
   s.description  = <<-DESC
                    Jayme defines a neat architecture for REST management in your Swift code. The idea behind this library is to separate concerns: Your view controllers should handle neither networking code nor heavy business logic code, in order to stay lightweight. The library provides a neat API to deal with REST communication, as well as default implementations for basic CRUD functionality and pagination.

--- a/Jayme/Compatibility.swift
+++ b/Jayme/Compatibility.swift
@@ -59,3 +59,17 @@ public typealias ServerPagedRepository = PagedRepository
 /// Identifier -> IdentifierType: CustomStringConvertible
 @available(*, unavailable, message : "Replace `Identifier` with any type that conforms to `CustomStringConvertible`.")
 public typealias Identifier = String
+
+extension Readable {
+    
+    @available(*, unavailable, renamed : "readAll")
+    public func findAll() -> Future<[EntityType], JaymeError> {
+        return self.readAll()
+    }
+    
+    @available(*, unavailable, renamed : "read(byId:)")
+    public func find(byId id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
+        return self.read(byId: id)
+    }
+    
+}

--- a/Jayme/Compatibility.swift
+++ b/Jayme/Compatibility.swift
@@ -67,9 +67,9 @@ extension Readable {
         return self.readAll()
     }
     
-    @available(*, unavailable, renamed : "read(byId:)")
+    @available(*, unavailable, renamed : "read(id:)")
     public func find(byId id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
-        return self.read(byId: id)
+        return self.read(id: id)
     }
     
 }

--- a/Jayme/Compatibility.swift
+++ b/Jayme/Compatibility.swift
@@ -73,3 +73,12 @@ extension Readable {
     }
     
 }
+
+extension Deletable {
+    
+    @available(*, unavailable, renamed : "delete(id:)")
+    public func delete(_ entity: EntityType) -> Future<Void, JaymeError> {
+        return self.delete(id: entity.id)
+    }
+    
+}

--- a/Jayme/Creatable.swift
+++ b/Jayme/Creatable.swift
@@ -28,12 +28,23 @@ public protocol Creatable: Repository {
 
 public extension Creatable {
     
-    /// Creates the entity in the repository. Returns a `Future` with the created entity or a `JaymeError`.
+    /// Requests an entity to be created in the backend.
+    /// Returns a `Future` with the created entity or a `JaymeError`.
     public func create(_ entity: EntityType) -> Future<EntityType, JaymeError> {
         let path = self.name
         return self.backend.future(path: path, method: .POST, parameters: entity.dictionaryValue)
             .andThen { DataParser().dictionary(from: $0.0) }
             .andThen { EntityParser().entity(from: $0) }
+    }
+    
+    /// Requests entities to be created in the backend.
+    /// Returns a `Future` with the created entities or a `JaymeError`.
+    public func create(_ entities: [EntityType]) -> Future<[EntityType], JaymeError> {
+        let path = self.name
+        let parameters = entities.map { $0.dictionaryValue }
+        return self.backend.future(path: path, method: .POST, parameters: parameters)
+            .andThen { DataParser().dictionaries(from: $0.0) }
+            .andThen { EntityParser().entities(from: $0) }
     }
     
 }

--- a/Jayme/Deletable.swift
+++ b/Jayme/Deletable.swift
@@ -28,9 +28,18 @@ public protocol Deletable: Repository {
 
 public extension Deletable {
     
-    /// Deletes the entity from the repository. Returns a `Future` with a `Void` result or a `JaymeError`.
-    public func delete(_ entity: EntityType) -> Future<Void, JaymeError> {
-        let path = "\(self.name)/\(entity.id)"
+    /// Requests the only entity to be deleted from the repository.
+    /// Returns a `Future` with a `Void` result or a `JaymeError`.
+    public func delete() -> Future<Void, JaymeError> {
+        let path = "\(self.name)"
+        return self.backend.future(path: path, method: .DELETE, parameters: nil)
+            .map { _ in return }
+    }
+    
+    /// Requests the entity matching the given `id` to be deleted from the repository.
+    /// Returns a `Future` with a `Void` result or a `JaymeError`.
+    public func delete(id: EntityType.IdentifierType) -> Future<Void, JaymeError> {
+        let path = "\(self.name)/\(id)"
         return self.backend.future(path: path, method: .DELETE, parameters: nil)
             .map { _ in return }
     }

--- a/Jayme/Readable.swift
+++ b/Jayme/Readable.swift
@@ -30,6 +30,7 @@ public extension Readable {
     
     /// Fetches the only entity from this repository
     /// Returns a `Future` containing the only entity in the repository, or the relevant `JaymeError` that could occur.
+    /// Watch out for a `.failure` case with `JaymeError.entityNotFound`.
     public func read() -> Future<EntityType, JaymeError> {
         let path = self.name
         return self.backend.future(path: path, method: .GET, parameters: nil)

--- a/Jayme/Readable.swift
+++ b/Jayme/Readable.swift
@@ -28,8 +28,16 @@ public protocol Readable: Repository {
 
 public extension Readable {
     
-    /// Returns a `Future` containing an array of all the entities in the repository, or the relevant `JaymeError` that could occur.
-    public func findAll() -> Future<[EntityType], JaymeError> {
+    /// Returns a `Future` containing the only entity in the repository, or the relevant `JaymeError` that could occur.
+    public func read() -> Future<EntityType, JaymeError> {
+        let path = self.name
+        return self.backend.future(path: path, method: .GET, parameters: nil)
+            .andThen { DataParser().dictionary(from: $0.0) }
+            .andThen { EntityParser().entity(from: $0) }
+    }
+    
+    /// Returns a `Future` containing an array with all the entities in the repository, or the relevant `JaymeError` that could occur.
+    public func readAll() -> Future<[EntityType], JaymeError> {
         let path = self.name
         return self.backend.future(path: path, method: .GET, parameters: nil)
             .andThen { DataParser().dictionaries(from: $0.0) }
@@ -38,7 +46,7 @@ public extension Readable {
     
     /// Returns a `Future` containing the entity matching the `id`, or the relevant `JaymeError` that could occur.
     /// Watch out for a `.failure` case with `JaymeError.entityNotFound`.
-    public func find(byId id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
+    public func read(byId id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
         let path = "\(self.name)/\(id)"
         return self.backend.future(path: path, method: .GET, parameters: nil)
             .andThen { DataParser().dictionary(from: $0.0) }

--- a/Jayme/Readable.swift
+++ b/Jayme/Readable.swift
@@ -28,6 +28,7 @@ public protocol Readable: Repository {
 
 public extension Readable {
     
+    /// Fetches the only entity from this repository
     /// Returns a `Future` containing the only entity in the repository, or the relevant `JaymeError` that could occur.
     public func read() -> Future<EntityType, JaymeError> {
         let path = self.name
@@ -36,6 +37,7 @@ public extension Readable {
             .andThen { EntityParser().entity(from: $0) }
     }
     
+    /// Fetches all the entities from this repository
     /// Returns a `Future` containing an array with all the entities in the repository, or the relevant `JaymeError` that could occur.
     public func readAll() -> Future<[EntityType], JaymeError> {
         let path = self.name
@@ -44,6 +46,7 @@ public extension Readable {
             .andThen { EntityParser().entities(from: $0) }
     }
     
+    /// Fetches only the entity from this repository that matches the given `id`
     /// Returns a `Future` containing the entity matching the `id`, or the relevant `JaymeError` that could occur.
     /// Watch out for a `.failure` case with `JaymeError.entityNotFound`.
     public func read(id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {

--- a/Jayme/Readable.swift
+++ b/Jayme/Readable.swift
@@ -46,7 +46,7 @@ public extension Readable {
     
     /// Returns a `Future` containing the entity matching the `id`, or the relevant `JaymeError` that could occur.
     /// Watch out for a `.failure` case with `JaymeError.entityNotFound`.
-    public func read(byId id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
+    public func read(id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
         let path = "\(self.name)/\(id)"
         return self.backend.future(path: path, method: .GET, parameters: nil)
             .andThen { DataParser().dictionary(from: $0.0) }

--- a/Jayme/URLSessionBackend.swift
+++ b/Jayme/URLSessionBackend.swift
@@ -42,6 +42,27 @@ open class URLSessionBackend: Backend {
     /// - A tuple with possible `NSData` relevant to the HTTP response and a possible `PageInfo` object if there is pagination-related info associated to it.
     /// - A `JaymeError` holding the error that occurred.
     open func future(path: Path, method: HTTPMethodName, parameters: [AnyHashable: Any]? = nil) -> Future<(Data?, PageInfo?), JaymeError> {
+        return self.createFuture(path: path, method: method, parameters: parameters)
+    }
+    
+    /// Returns a `Future` containing either:
+    /// - A tuple with possible `NSData` relevant to the HTTP response and a possible `PageInfo` object if there is pagination-related info associated to it.
+    /// - A `JaymeError` holding the error that occurred.
+    open func future(path: Path, method: HTTPMethodName, parameters: [[AnyHashable: Any]]) -> Future<(Data?, PageInfo?), JaymeError> {
+        return self.createFuture(path: path, method: method, parameters: parameters)
+    }
+    
+    // MARK: - Private
+    
+    fileprivate var baseURL: URL? {
+        return URL(string: self.configuration.basePath)
+    }
+    
+    fileprivate func url(for path: Path) -> URL? {
+        return self.baseURL?.appendingPathComponent(path)
+    }
+    
+    fileprivate func createFuture(path: Path, method: HTTPMethodName, parameters: Any? = nil) -> Future<(Data?, PageInfo?), JaymeError> {
         return Future() { completion in
             guard let request = try? self.request(path: path, method: method, parameters: parameters) else {
                 completion(.failure(JaymeError.badRequest))
@@ -68,17 +89,7 @@ open class URLSessionBackend: Backend {
         }
     }
     
-    // MARK: - Private
-    
-    fileprivate var baseURL: URL? {
-        return URL(string: self.configuration.basePath)
-    }
-    
-    fileprivate func url(for path: Path) -> URL? {
-        return self.baseURL?.appendingPathComponent(path)
-    }
-    
-    fileprivate func request(path: Path, method: HTTPMethodName, parameters: [AnyHashable: Any]?) throws -> URLRequest {
+    fileprivate func request(path: Path, method: HTTPMethodName, parameters: Any?) throws -> URLRequest {
         guard let url = self.url(for: path) else {
             throw JaymeError.badRequest
         }

--- a/Jayme/Updatable.swift
+++ b/Jayme/Updatable.swift
@@ -28,7 +28,7 @@ public protocol Updatable: Repository {
 
 public extension Updatable {
     
-    /// Updates the only entity in the repository. Returns a `Future` with the updated entity or a `JaymeError`.
+    /// Requests the only entity in the repository to be updated in the backend. Returns a `Future` with the updated entity or a `JaymeError`.
     public func update(_ entity: EntityType) -> Future<EntityType, JaymeError> {
         let path = "\(self.name)"
         return self.backend.future(path: path, method: .PUT, parameters: entity.dictionaryValue)
@@ -36,7 +36,7 @@ public extension Updatable {
             .andThen { EntityParser().entity(from: $0) }
     }
     
-    /// Updates the entity with the given id in the repository. Returns a `Future` with the updated entity or a `JaymeError`.
+    /// Requests the entity with the given `id` to be updated in the backend. Returns a `Future` with the updated entity or a `JaymeError`.
     public func update(_ entity: EntityType, id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
         let path = "\(self.name)/\(entity.id)"
         return self.backend.future(path: path, method: .PUT, parameters: entity.dictionaryValue)

--- a/Jayme/Updatable.swift
+++ b/Jayme/Updatable.swift
@@ -44,4 +44,13 @@ public extension Updatable {
             .andThen { EntityParser().entity(from: $0) }
     }
     
+    /// Requests the given entities to be updated in the backend. Returns a `Future` with the updated entities or a `JaymeError`.
+    public func update(_ entities: [EntityType]) -> Future<[EntityType], JaymeError> {
+        let path = self.name
+        let parameters = entities.map { $0.dictionaryValue }
+        return self.backend.future(path: path, method: .PATCH, parameters: parameters)
+            .andThen { DataParser().dictionaries(from: $0.0) }
+            .andThen { EntityParser().entities(from: $0) }
+    }
+    
 }

--- a/Jayme/Updatable.swift
+++ b/Jayme/Updatable.swift
@@ -28,8 +28,16 @@ public protocol Updatable: Repository {
 
 public extension Updatable {
     
-    /// Updates the entity in the repository. Returns a `Future` with the updated entity or a `JaymeError`.
+    /// Updates the only entity in the repository. Returns a `Future` with the updated entity or a `JaymeError`.
     public func update(_ entity: EntityType) -> Future<EntityType, JaymeError> {
+        let path = "\(self.name)"
+        return self.backend.future(path: path, method: .PUT, parameters: entity.dictionaryValue)
+            .andThen { DataParser().dictionary(from: $0.0) }
+            .andThen { EntityParser().entity(from: $0) }
+    }
+    
+    /// Updates the entity with the given id in the repository. Returns a `Future` with the updated entity or a `JaymeError`.
+    public func update(_ entity: EntityType, id: EntityType.IdentifierType) -> Future<EntityType, JaymeError> {
         let path = "\(self.name)/\(entity.id)"
         return self.backend.future(path: path, method: .PUT, parameters: entity.dictionaryValue)
             .andThen { DataParser().dictionary(from: $0.0) }

--- a/JaymeTests/CreatableTests.swift
+++ b/JaymeTests/CreatableTests.swift
@@ -37,6 +37,8 @@ class CreatableTests: XCTestCase {
     
 }
 
+// MARK: - Create Single Entity
+
 extension CreatableTests {
     
     // MARK: - Call To backend
@@ -54,25 +56,6 @@ extension CreatableTests {
         }
         XCTAssertEqual(id, "123")
         XCTAssertEqual(name, "a")
-    }
-    
-    func testCreateEntitiesCall() {
-        let doc1 = TestDocument(id: "1", name: "doc1")
-        let doc2 = TestDocument(id: "2", name: "doc2")
-        let _ = self.repository.create([doc1, doc2])
-        XCTAssertEqual(self.backend.path, "documents")
-        XCTAssertEqual(self.backend.method, .POST)
-        XCTAssertEqual(self.backend.parametersAsArray?.count, 2)
-        guard
-            let id1 = self.backend.parametersAsArray?[0]["id"] as? String,
-            let name1 = self.backend.parametersAsArray?[0]["name"] as? String,
-            let id2 = self.backend.parametersAsArray?[1]["id"] as? String,
-            let name2 = self.backend.parametersAsArray?[1]["name"] as? String
-            else { XCTFail("Wrong parameters"); return }
-        XCTAssertEqual(id1, "1")
-        XCTAssertEqual(name1, "doc1")
-        XCTAssertEqual(id2, "2")
-        XCTAssertEqual(name2, "doc2")
     }
     
     // MARK: - Success Response
@@ -103,6 +86,60 @@ extension CreatableTests {
         }
     }
     
+    // MARK: - Failure Response
+    
+    func testCreateEntityFailureCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let error = JaymeError.notFound
+            completion(.failure(error))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get an error")
+        
+        let document = TestDocument(id: "_", name: "_")
+        let future = self.repository.create(document)
+        future.start() { result in
+            guard case .failure = result
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+
+}
+
+// MARK: - Create Multiple Entities
+
+extension CreatableTests {
+    
+    // MARK: - Call To backend
+    
+    func testCreateEntitiesCall() {
+        let doc1 = TestDocument(id: "1", name: "doc1")
+        let doc2 = TestDocument(id: "2", name: "doc2")
+        let _ = self.repository.create([doc1, doc2])
+        XCTAssertEqual(self.backend.path, "documents")
+        XCTAssertEqual(self.backend.method, .POST)
+        XCTAssertEqual(self.backend.parametersAsArray?.count, 2)
+        guard
+            let id1 = self.backend.parametersAsArray?[0]["id"] as? String,
+            let name1 = self.backend.parametersAsArray?[0]["name"] as? String,
+            let id2 = self.backend.parametersAsArray?[1]["id"] as? String,
+            let name2 = self.backend.parametersAsArray?[1]["name"] as? String
+            else { XCTFail("Wrong parameters"); return }
+        XCTAssertEqual(id1, "1")
+        XCTAssertEqual(name1, "doc1")
+        XCTAssertEqual(id2, "2")
+        XCTAssertEqual(name2, "doc2")
+    }
+    
+    // MARK: - Success Response
+    
     func testCreateEntitiesSuccessCallback() {
         
         // Simulated completion
@@ -131,31 +168,8 @@ extension CreatableTests {
             if let _ = error { XCTFail() }
         }
     }
-
-    // MARK: - Failure Response
     
-    func testCreateEntityFailureCallback() {
-        
-        // Simulated completion
-        self.backend.completion = { completion in
-            let error = JaymeError.notFound
-            completion(.failure(error))
-        }
-        
-        let expectation = self.expectation(description: "Expected to get an error")
-        
-        let document = TestDocument(id: "_", name: "_")
-        let future = self.repository.create(document)
-        future.start() { result in
-            guard case .failure = result
-                else { XCTFail(); return }
-            expectation.fulfill()
-        }
-        
-        self.waitForExpectations(timeout: 3) { error in
-            if let _ = error { XCTFail() }
-        }
-    }
+    // MARK: - Failure Response
     
     func testCreateEntitiesFailureCallback() {
         
@@ -179,5 +193,5 @@ extension CreatableTests {
             if let _ = error { XCTFail() }
         }
     }
-
+    
 }

--- a/JaymeTests/CreatableTests.swift
+++ b/JaymeTests/CreatableTests.swift
@@ -41,7 +41,7 @@ extension CreatableTests {
     
     // MARK: - Call To backend
     
-    func testCreateCall() {
+    func testCreateEntityCall() {
         let document = TestDocument(id: "123", name: "a")
         let _ = self.repository.create(document)
         XCTAssertEqual(self.backend.path, "documents")
@@ -56,9 +56,28 @@ extension CreatableTests {
         XCTAssertEqual(name, "a")
     }
     
+    func testCreateEntitiesCall() {
+        let doc1 = TestDocument(id: "1", name: "doc1")
+        let doc2 = TestDocument(id: "2", name: "doc2")
+        let _ = self.repository.create([doc1, doc2])
+        XCTAssertEqual(self.backend.path, "documents")
+        XCTAssertEqual(self.backend.method, .POST)
+        XCTAssertEqual(self.backend.parametersAsArray?.count, 2)
+        guard
+            let id1 = self.backend.parametersAsArray?[0]["id"] as? String,
+            let name1 = self.backend.parametersAsArray?[0]["name"] as? String,
+            let id2 = self.backend.parametersAsArray?[1]["id"] as? String,
+            let name2 = self.backend.parametersAsArray?[1]["name"] as? String
+            else { XCTFail("Wrong parameters"); return }
+        XCTAssertEqual(id1, "1")
+        XCTAssertEqual(name1, "doc1")
+        XCTAssertEqual(id2, "2")
+        XCTAssertEqual(name2, "doc2")
+    }
+    
     // MARK: - Success Response
     
-    func testCreateSuccessCallback() {
+    func testCreateEntitySuccessCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -83,10 +102,39 @@ extension CreatableTests {
             if let _ = error { XCTFail() }
         }
     }
+    
+    func testCreateEntitiesSuccessCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let json = [["id": "1", "name": "a"], ["id": "2", "name": "b"]]
+            let data = try! JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+            completion(.success((data, nil)))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get a success")
+        
+        let documents: [TestDocument] = []
+        let future = self.repository.create(documents)
+        future.start() { result in
+            guard case .success(let docs) = result
+                else { XCTFail(); return }
+            XCTAssertEqual(docs.count, 2)
+            XCTAssertEqual(docs[0].id, "1")
+            XCTAssertEqual(docs[0].name, "a")
+            XCTAssertEqual(docs[1].id, "2")
+            XCTAssertEqual(docs[1].name, "b")
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
 
     // MARK: - Failure Response
     
-    func testCreateFailureCallback() {
+    func testCreateEntityFailureCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -98,6 +146,29 @@ extension CreatableTests {
         
         let document = TestDocument(id: "_", name: "_")
         let future = self.repository.create(document)
+        future.start() { result in
+            guard case .failure = result
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+    
+    func testCreateEntitiesFailureCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let error = JaymeError.notFound
+            completion(.failure(error))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get an error")
+        
+        let documents: [TestDocument] = []
+        let future = self.repository.create(documents)
         future.start() { result in
             guard case .failure = result
                 else { XCTFail(); return }

--- a/JaymeTests/DeletableTests.swift
+++ b/JaymeTests/DeletableTests.swift
@@ -37,20 +37,21 @@ class DeletableTests: XCTestCase {
     
 }
 
+// MARK: - Delete Single Entity
+
 extension DeletableTests {
     
-    // MARK: - Call To backend
+    // MARK: - Call To Backend
     
-    func testDeleteCall() {
-        let document = TestDocument(id: "123", name: "a")
-        let _ = self.repository.delete(document)
-        XCTAssertEqual(self.backend.path, "documents/123")
+    func testDeleteSingleEntityCall() {
+        let _ = self.repository.delete()
+        XCTAssertEqual(self.backend.path, "documents")
         XCTAssertEqual(self.backend.method, .DELETE)
     }
     
     // MARK: - Success Response
     
-    func testDeleteSuccessCallback() {
+    func testDeleteSingleEntitySuccessCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -59,8 +60,7 @@ extension DeletableTests {
         
         let expectation = self.expectation(description: "Expected to get a success")
         
-        let document = TestDocument(id: "_", name: "_")
-        let future = self.repository.delete(document)
+        let future = self.repository.delete()
         future.start() { result in
             guard case .success = result
                 else { XCTFail(); return }
@@ -74,7 +74,7 @@ extension DeletableTests {
     
     // MARK: - Failure Response
     
-    func testDeleteFailureCallback() {
+    func testDeleteSingleEntityFailureCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -84,8 +84,68 @@ extension DeletableTests {
         
         let expectation = self.expectation(description: "Expected to get an error")
         
-        let document = TestDocument(id: "_", name: "_")
-        let future = self.repository.delete(document)
+        let future = self.repository.delete()
+        future.start() { result in
+            guard case .failure = result
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+    
+}
+
+// MARK: - Delete By Id
+
+extension DeletableTests {
+    
+    // MARK: - Call To Backend
+    
+    func testDeleteByIdCall() {
+        let _ = self.repository.delete(id: "123")
+        XCTAssertEqual(self.backend.path, "documents/123")
+        XCTAssertEqual(self.backend.method, .DELETE)
+    }
+    
+    // MARK: - Success Response
+    
+    func testDeleteByIdSuccessCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            completion(.success((nil, nil)))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get a success")
+        
+        let future = self.repository.delete(id: "_")
+        future.start() { result in
+            guard case .success = result
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+    
+    // MARK: - Failure Response
+    
+    func testDeleteByIdFailureCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let error = JaymeError.notFound
+            completion(.failure(error))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get an error")
+        
+        let future = self.repository.delete(id: "_")
         future.start() { result in
             guard case .failure = result
                 else { XCTFail(); return }

--- a/JaymeTests/ReadableTests.swift
+++ b/JaymeTests/ReadableTests.swift
@@ -37,21 +37,21 @@ class ReadableTests: XCTestCase {
     
 }
 
-// MARK: - Find All
+// MARK: - Read All
 
 extension ReadableTests {
     
     // MARK: - Call To Backend
     
-    func testFindAllCall() {
-        let _ = self.repository.findAll()
+    func testReadAllCall() {
+        let _ = self.repository.readAll()
         XCTAssertEqual(self.backend.path, "documents")
         XCTAssertEqual(self.backend.method, .GET)
     }
     
     // MARK: - Success Response
     
-    func testFindAllSuccessCallback() {
+    func testReadAllSuccessCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -63,7 +63,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected 2 documents to be parsed")
         
-        let future = self.repository.findAll()
+        let future = self.repository.readAll()
         future.start() { result in
             guard case .success(let documents) = result
                 else { XCTFail(); return }
@@ -82,7 +82,7 @@ extension ReadableTests {
     
     // MARK: - Failure Response
     
-    func testFindAllFailureNotFoundCallback() {
+    func testReadAllFailureNotFoundCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -92,7 +92,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected JaymeError.NotFound")
         
-        let future = self.repository.findAll()
+        let future = self.repository.readAll()
         future.start() { result in
             guard case .failure = result
                 else { XCTFail(); return }
@@ -104,7 +104,7 @@ extension ReadableTests {
         }
     }
     
-    func testFindAllFailureBadResponseCallback() {
+    func testReadAllFailureBadResponseCallback() {
         // Simulated completion
         self.backend.completion = { completion in
             let corruptedData = Data()
@@ -113,7 +113,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected to get a JaymeError.BadResponse")
         
-        let future = self.repository.findAll()
+        let future = self.repository.readAll()
         future.start() { result in
             guard
                 case .failure(let error) = result,
@@ -128,21 +128,21 @@ extension ReadableTests {
     }
 }
 
-// MARK: - Find By ID
+// MARK: - Read By ID
 
 extension ReadableTests {
     
     // MARK: - Call To Backend
     
-    func testFindByIdCall() {
-        let _ = self.repository.find(byId: "123")
+    func testReadByIdCall() {
+        let _ = self.repository.read(byId: "123")
         XCTAssertEqual(self.backend.path, "documents/123")
         XCTAssertEqual(self.backend.method, .GET)
     }
     
     // MARK: - Success Response
     
-    func testFindByIdSuccessCallback() {
+    func testReadByIdSuccessCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -153,7 +153,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected to find a document")
         
-        let future = self.repository.find(byId: "1")
+        let future = self.repository.read(byId: "1")
         future.start() { result in
             guard case .success(let document) = result
                 else { XCTFail(); return }
@@ -169,7 +169,7 @@ extension ReadableTests {
     
     // MARK: - Failure Response
     
-    func testFindByIdFailureNotFoundCallback() {
+    func testReadByIdFailureNotFoundCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -179,7 +179,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected to get JaymeError.NotFound")
         
-        let future = self.repository.find(byId: "_")
+        let future = self.repository.read(byId: "_")
         future.start() { result in
             guard
                 case .failure(let error) = result,
@@ -193,7 +193,7 @@ extension ReadableTests {
         }
     }
     
-    func testFindByIdFailureBadResponseCallback() {
+    func testReadByIdFailureBadResponseCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -203,7 +203,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected to get JaymeError.BadResponse")
         
-        let future = self.repository.find(byId: "_")
+        let future = self.repository.read(byId: "_")
         future.start() { result in
             guard
                 case .failure(let error) = result,
@@ -217,7 +217,7 @@ extension ReadableTests {
         }
     }
     
-    func testFindByIdFailureParsingErrorCallback() {
+    func testReadByIdFailureParsingErrorCallback() {
         
         // Simulated completion
         self.backend.completion = { completion in
@@ -228,7 +228,98 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected to get JaymeError.ParsingError")
         
-        let future = self.repository.find(byId: "_")
+        let future = self.repository.read(byId: "_")
+        future.start() { result in
+            guard
+                case .failure(let error) = result,
+                case .parsingError = error
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+}
+
+// MARK: - Read (Single Entity)
+
+extension ReadableTests {
+    
+    // MARK: - Call To Backend
+    
+    func testReadSingleEntityCall() {
+        let _ = self.repository.read()
+        XCTAssertEqual(self.backend.path, "documents")
+        XCTAssertEqual(self.backend.method, .GET)
+    }
+    
+    // MARK: - Success Response
+    
+    func testReadSingleEntitySuccessCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let json = ["id": "1", "name": "a"]
+            let data = try! JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+            completion(.success((data, nil)))
+        }
+        
+        let expectation = self.expectation(description: "Expected to find a document")
+        
+        let future = self.repository.read()
+        future.start() { result in
+            guard case .success(let document) = result
+                else { XCTFail(); return }
+            XCTAssertEqual(document.id, "1")
+            XCTAssertEqual(document.name, "a")
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+    
+    // MARK: - Failure Response
+    
+    func testReadSingleEntityFailureBadResponseCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let corruptedData = Data()
+            completion(.success((corruptedData, nil)))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get JaymeError.BadResponse")
+        
+        let future = self.repository.read()
+        future.start() { result in
+            guard
+                case .failure(let error) = result,
+                case .badResponse = error
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+    
+    func testReadSingleEntityFailureParsingErrorCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let wrongDictionary = ["id": "_"] // lacks 'name' field
+            let data = try! JSONSerialization.data(withJSONObject: wrongDictionary, options: .prettyPrinted)
+            completion(.success((data, nil)))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get JaymeError.ParsingError")
+        
+        let future = self.repository.read()
         future.start() { result in
             guard
                 case .failure(let error) = result,

--- a/JaymeTests/ReadableTests.swift
+++ b/JaymeTests/ReadableTests.swift
@@ -135,7 +135,7 @@ extension ReadableTests {
     // MARK: - Call To Backend
     
     func testReadByIdCall() {
-        let _ = self.repository.read(byId: "123")
+        let _ = self.repository.read(id: "123")
         XCTAssertEqual(self.backend.path, "documents/123")
         XCTAssertEqual(self.backend.method, .GET)
     }
@@ -153,7 +153,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected to find a document")
         
-        let future = self.repository.read(byId: "1")
+        let future = self.repository.read(id: "1")
         future.start() { result in
             guard case .success(let document) = result
                 else { XCTFail(); return }
@@ -179,7 +179,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected to get JaymeError.NotFound")
         
-        let future = self.repository.read(byId: "_")
+        let future = self.repository.read(id: "_")
         future.start() { result in
             guard
                 case .failure(let error) = result,
@@ -203,7 +203,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected to get JaymeError.BadResponse")
         
-        let future = self.repository.read(byId: "_")
+        let future = self.repository.read(id: "_")
         future.start() { result in
             guard
                 case .failure(let error) = result,
@@ -228,7 +228,7 @@ extension ReadableTests {
         
         let expectation = self.expectation(description: "Expected to get JaymeError.ParsingError")
         
-        let future = self.repository.read(byId: "_")
+        let future = self.repository.read(id: "_")
         future.start() { result in
             guard
                 case .failure(let error) = result,

--- a/JaymeTests/TestingBackend.swift
+++ b/JaymeTests/TestingBackend.swift
@@ -26,6 +26,7 @@ class TestingBackend: URLSessionBackend {
     var path: Path?
     var method: HTTPMethodName?
     var parameters: [AnyHashable: Any]?
+    var parametersAsArray: [[AnyHashable: Any]]?
     
     var completion: Future<(Data?, PageInfo?), JaymeError>.FutureAsyncOperation = { completion in }
     
@@ -33,6 +34,13 @@ class TestingBackend: URLSessionBackend {
         self.path = path
         self.method = method
         self.parameters = parameters
+        return Future(operation: self.completion)
+    }
+    
+    override func future(path: String, method: HTTPMethodName, parameters: [[AnyHashable: Any]]? = nil) -> Future <(Data?, PageInfo?), JaymeError> {
+        self.path = path
+        self.method = method
+        self.parametersAsArray = parameters
         return Future(operation: self.completion)
     }
     

--- a/JaymeTests/URLSessionBackendTests.swift
+++ b/JaymeTests/URLSessionBackendTests.swift
@@ -54,8 +54,8 @@ extension URLSessionBackendTests {
     func testBadParameters() {
         let backend = URLSessionBackend()
         let problematicString = String(bytes: [0xD8, 0x00] as [UInt8], encoding: String.Encoding.utf16BigEndian)!
-        let problematicParams = ["foo": problematicString]
-        let future = backend.future(path: "_", method: .GET, parameters: problematicParams as [String : AnyObject]?)
+        let problematicParams: [[AnyHashable: Any]] = [["foo": problematicString]]
+        let future = backend.future(path: "_", method: .GET, parameters: problematicParams)
         let expectation = self.expectation(description: "Expected .Failure with .BadRequest error")
         future.start { result in
             guard

--- a/JaymeTests/UpdatableTests.swift
+++ b/JaymeTests/UpdatableTests.swift
@@ -188,3 +188,88 @@ extension UpdatableTests {
     }
     
 }
+
+// MARK: - Update Multiple Entities
+
+extension UpdatableTests {
+    
+    // MARK: - Call To backend
+    
+    func testUpdateEntitiesCall() {
+        let documents = [TestDocument(id: "1", name: "doc1"),
+                        TestDocument(id: "2", name: "doc2")]
+        let _ = self.repository.update(documents)
+        XCTAssertEqual(self.backend.path, "documents")
+        XCTAssertEqual(self.backend.method, .PATCH)
+        XCTAssertEqual(self.backend.parametersAsArray.count, 2)
+        guard
+            let id1 = self.backend.parametersAsArray?[0]["id"] as? String,
+            let name1 = self.backend.parametersAsArray?[0]["name"] as? String,
+            let id2 = self.backend.parametersAsArray?[1]["id"] as? String,
+            let name2 = self.backend.parametersAsArray?[1]["name"] as? String
+        else { XCTFail("Wrong parameters"); return }
+        XCTAssertEqual(id1, "1")
+        XCTAssertEqual(name1, "doc1")
+        XCTAssertEqual(id2, "2")
+        XCTAssertEqual(name2, "doc2")
+    }
+    
+    // MARK: - Success Response
+    
+    func testUpdateEntitiesSuccessCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let json = [["id": "1", "name": "a"], ["id": "2", "name": "b"]]
+            let data = try! JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
+            completion(.success((data, nil)))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get a success")
+        
+        let documents: [TestDocument] = []
+        let future = self.repository.update(documents)
+        future.start() { result in
+            guard case .success(let docs) = result
+                else { XCTFail(); return }
+            XCTAssertEqual(docs.count, 2)
+            XCTAssertEqual(docs[0].id, "1")
+            XCTAssertEqual(docs[0].name, "a")
+            XCTAssertEqual(docs[1].id, "2")
+            XCTAssertEqual(docs[1].name, "b")
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+        
+    }
+    
+    // MARK: - Failure Response
+    
+    func testUpdateEntitiesFailureCallback() {
+        
+        // Simulated completion
+        self.backend.completion = { completion in
+            let error = JaymeError.notFound
+            completion(.failure(error))
+        }
+        
+        let expectation = self.expectation(description: "Expected to get an error")
+        
+        let documents: [TestDocument] = []
+        let future = self.repository.update(documents)
+        future.start() { result in
+            guard case .failure = result
+                else { XCTFail(); return }
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 3) { error in
+            if let _ = error { XCTFail() }
+        }
+    }
+    
+}
+

--- a/JaymeTests/UpdatableTests.swift
+++ b/JaymeTests/UpdatableTests.swift
@@ -201,7 +201,7 @@ extension UpdatableTests {
         let _ = self.repository.update(documents)
         XCTAssertEqual(self.backend.path, "documents")
         XCTAssertEqual(self.backend.method, .PATCH)
-        XCTAssertEqual(self.backend.parametersAsArray.count, 2)
+        XCTAssertEqual(self.backend.parametersAsArray?.count, 2)
         guard
             let id1 = self.backend.parametersAsArray?[0]["id"] as? String,
             let name1 = self.backend.parametersAsArray?[0]["name"] as? String,

--- a/JaymeTests/UpdatableTests.swift
+++ b/JaymeTests/UpdatableTests.swift
@@ -272,4 +272,3 @@ extension UpdatableTests {
     }
     
 }
-


### PR DESCRIPTION
This PR solves issue #87

- Added new methods to the current CRUD protocols, allowing final users to develop towards *single-entity* repositories or *multiple-entity* repositories
- Bumped the version to `4.0.0`, since there are some breaking changes in the APIs
- Updated the CHANGELOG
- Added a 4.0 Migration Guide, explaining the new features and how changes impact existing code
